### PR TITLE
Integration tests for Hudi and Iceberg output formats

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
@@ -56,6 +56,15 @@ object Config {
     def table: String
   }
 
+  case class IcebergHadoop(
+    database: String,
+    table: String,
+    location: URI
+  ) extends Iceberg {
+
+    override def sparkDatabase: String = database
+  }
+
   case class IcebergSnowflake(
     host: String,
     user: String,

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/LakeWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/LakeWriter.scala
@@ -15,7 +15,14 @@ import org.apache.spark.sql.types.StructType
 
 import com.snowplowanalytics.snowplow.runtime.HealthProbe
 import com.snowplowanalytics.snowplow.lakes.Config
-import com.snowplowanalytics.snowplow.lakes.tables.{DeltaWriter, HudiWriter, IcebergBigLakeWriter, IcebergSnowflakeWriter, Writer}
+import com.snowplowanalytics.snowplow.lakes.tables.{
+  DeltaWriter,
+  HudiWriter,
+  IcebergBigLakeWriter,
+  IcebergHadoopWriter,
+  IcebergSnowflakeWriter,
+  Writer
+}
 
 trait LakeWriter[F[_]] {
 
@@ -37,6 +44,7 @@ object LakeWriter {
     val w = target match {
       case c: Config.Delta            => new DeltaWriter(c)
       case c: Config.Hudi             => new HudiWriter(c)
+      case c: Config.IcebergHadoop    => new IcebergHadoopWriter(c)
       case c: Config.IcebergBigLake   => new IcebergBigLakeWriter(c)
       case c: Config.IcebergSnowflake => new IcebergSnowflakeWriter(c)
     }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergHadoopWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergHadoopWriter.scala
@@ -9,24 +9,12 @@ package com.snowplowanalytics.snowplow.lakes.tables
 
 import com.snowplowanalytics.snowplow.lakes.Config
 
-class IcebergBigLakeWriter(config: Config.IcebergBigLake) extends IcebergWriter(config) {
-
+class IcebergHadoopWriter(config: Config.IcebergHadoop) extends IcebergWriter.WithDefaults(config) {
   override def sparkConfig: Map[String, String] =
     Map(
       "spark.sql.extensions" -> "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
       s"spark.sql.catalog.$sparkCatalog" -> "org.apache.iceberg.spark.SparkCatalog",
-      s"spark.sql.catalog.$sparkCatalog.catalog-impl" -> "org.apache.iceberg.gcp.biglake.BigLakeCatalog",
-      s"spark.sql.catalog.$sparkCatalog.gcp_project" -> config.project,
-      s"spark.sql.catalog.$sparkCatalog.gcp_location" -> config.region,
-      s"spark.sql.catalog.$sparkCatalog.blms_catalog" -> config.catalog,
+      s"spark.sql.catalog.$sparkCatalog.type" -> "hadoop",
       s"spark.sql.catalog.$sparkCatalog.warehouse" -> config.location.toString
     )
-
-  override def extraTableProperties: Map[String, String] =
-    Map(
-      "bq_table" -> s"${config.bqDataset}.${config.table}",
-      "bq_connection" -> s"projects/${config.project}/locations/${config.region}/connections/${config.connection}"
-    )
-
-  override def requiresCreateNamespace: Boolean = true
 }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergSnowflakeWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergSnowflakeWriter.scala
@@ -9,7 +9,7 @@ package com.snowplowanalytics.snowplow.lakes.tables
 
 import com.snowplowanalytics.snowplow.lakes.Config
 
-class IcebergSnowflakeWriter(config: Config.IcebergSnowflake) extends IcebergWriter(config) {
+class IcebergSnowflakeWriter(config: Config.IcebergSnowflake) extends IcebergWriter.WithDefaults(config) {
 
   override def sparkConfig: Map[String, String] =
     Map(

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/TestConfig.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/TestConfig.scala
@@ -14,20 +14,20 @@ import io.circe.config.syntax._
 object TestConfig {
 
   /** Provides an app Config using defaults provided by our standard reference.conf */
-  def defaults: AnyConfig =
+  def defaults(overrides: String = fallbacks): AnyConfig =
     ConfigFactory
-      .load(fallbacks)
+      .load(ConfigFactory.parseString(overrides))
       .as[Config[Option[Unit], Option[Unit]]] match {
       case Right(ok) => ok
       case Left(e)   => throw new RuntimeException("Could not load default config for testing", e)
     }
 
-  private def fallbacks = ConfigFactory.parseString("""
+  private def fallbacks = """
     output: {
       good: {
         type: Delta
         location: "file:///tmp/lake-loader-test/events"
       }
     }
-  """)
+  """
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/DeltaSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/DeltaSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.lakes.processing
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import com.snowplowanalytics.snowplow.lakes.TestSparkEnvironment
+
+import java.nio.file.Path
+
+class DeltaSpec extends AbstractSparkSpec {
+
+  override def target: TestSparkEnvironment.Target = TestSparkEnvironment.Delta
+
+  /** Reads the table back into memory, so we can make assertions on the app's output */
+  override def readTable(spark: SparkSession, tmpDir: Path): DataFrame = {
+    val location = tmpDir.resolve("events").toString
+    spark.sql(s"""
+      CREATE TABLE events USING delta
+      LOCATION '$location'
+    """)
+    spark.sql("select * from events")
+  }
+
+  /** Spark config used only while reading table back into memory for assertions */
+  override def sparkConfig(tmpDir: Path): Map[String, String] =
+    Map(
+      "spark.sql.extensions" -> "io.delta.sql.DeltaSparkSessionExtension",
+      "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.delta.catalog.DeltaCatalog"
+    )
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/DeltaSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/DeltaSpec.scala
@@ -9,17 +9,17 @@ package com.snowplowanalytics.snowplow.lakes.processing
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-import com.snowplowanalytics.snowplow.lakes.TestSparkEnvironment
+import com.snowplowanalytics.snowplow.lakes.TestConfig
 
-import java.nio.file.Path
+import fs2.io.file.Path
 
 class DeltaSpec extends AbstractSparkSpec {
 
-  override def target: TestSparkEnvironment.Target = TestSparkEnvironment.Delta
+  override def target: TestConfig.Target = TestConfig.Delta
 
   /** Reads the table back into memory, so we can make assertions on the app's output */
   override def readTable(spark: SparkSession, tmpDir: Path): DataFrame = {
-    val location = tmpDir.resolve("events").toString
+    val location = (tmpDir / "events").toString
     spark.sql(s"""
       CREATE TABLE events USING delta
       LOCATION '$location'

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/HudiSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/HudiSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.lakes.processing
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import com.snowplowanalytics.snowplow.lakes.TestSparkEnvironment
+
+import java.nio.file.Path
+
+class HudiSpec extends AbstractSparkSpec {
+
+  override def target: TestSparkEnvironment.Target = TestSparkEnvironment.Hudi
+
+  /** Reads the table back into memory, so we can make assertions on the app's output */
+  override def readTable(spark: SparkSession, tmpDir: Path): DataFrame = {
+    val location = tmpDir.resolve("events").toString
+    spark.sql(s"""
+      CREATE TABLE events USING hudi
+      LOCATION '$location'
+    """)
+    spark.sql("select * from events")
+  }
+
+  /** Spark config used only while reading table back into memory for assertions */
+  override def sparkConfig(tmpDir: Path): Map[String, String] =
+    Map(
+      "spark.sql.extensions" -> "org.apache.spark.sql.hudi.HoodieSparkSessionExtension",
+      "spark.sql.catalog.spark_catalog" -> "org.apache.spark.sql.hudi.catalog.HoodieCatalog"
+    )
+
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/HudiSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/HudiSpec.scala
@@ -9,17 +9,17 @@ package com.snowplowanalytics.snowplow.lakes.processing
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-import com.snowplowanalytics.snowplow.lakes.TestSparkEnvironment
+import com.snowplowanalytics.snowplow.lakes.TestConfig
 
-import java.nio.file.Path
+import fs2.io.file.Path
 
 class HudiSpec extends AbstractSparkSpec {
 
-  override def target: TestSparkEnvironment.Target = TestSparkEnvironment.Hudi
+  override def target: TestConfig.Target = TestConfig.Hudi
 
   /** Reads the table back into memory, so we can make assertions on the app's output */
   override def readTable(spark: SparkSession, tmpDir: Path): DataFrame = {
-    val location = tmpDir.resolve("events").toString
+    val location = (tmpDir / "events").toString
     spark.sql(s"""
       CREATE TABLE events USING hudi
       LOCATION '$location'

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/IcebergSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/IcebergSpec.scala
@@ -9,13 +9,13 @@ package com.snowplowanalytics.snowplow.lakes.processing
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-import com.snowplowanalytics.snowplow.lakes.TestSparkEnvironment
+import com.snowplowanalytics.snowplow.lakes.TestConfig
 
-import java.nio.file.Path
+import fs2.io.file.Path
 
 class IcebergSpec extends AbstractSparkSpec {
 
-  override def target: TestSparkEnvironment.Target = TestSparkEnvironment.Iceberg
+  override def target: TestConfig.Target = TestConfig.Iceberg
 
   /** Reads the table back into memory, so we can make assertions on the app's output */
   override def readTable(spark: SparkSession, tmpDir: Path): DataFrame =

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/IcebergSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/IcebergSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.lakes.processing
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import com.snowplowanalytics.snowplow.lakes.TestSparkEnvironment
+
+import java.nio.file.Path
+
+class IcebergSpec extends AbstractSparkSpec {
+
+  override def target: TestSparkEnvironment.Target = TestSparkEnvironment.Iceberg
+
+  /** Reads the table back into memory, so we can make assertions on the app's output */
+  override def readTable(spark: SparkSession, tmpDir: Path): DataFrame =
+    spark.sql("select * from test_catalog.test.events")
+
+  /** Spark config used only while reading table back into memory for assertions */
+  override def sparkConfig(tmpDir: Path): Map[String, String] =
+    Map(
+      "spark.sql.extensions" -> "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+      "spark.sql.catalog.test_catalog" -> "org.apache.iceberg.spark.SparkCatalog",
+      "spark.sql.catalog.test_catalog.type" -> "hadoop",
+      "spark.sql.catalog.test_catalog.warehouse" -> tmpDir.toString
+    )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,6 +59,7 @@ object Dependencies {
   // spark and hadoop
   val sparkCore    = "org.apache.spark"           %% "spark-core"                % V.spark
   val sparkSql     = "org.apache.spark"           %% "spark-sql"                 % V.spark
+  val sparkHive    = "org.apache.spark"           %% "spark-hive"                % V.spark
   val delta        = "io.delta"                   %% "delta-core"                % V.delta
   val hudi         = "org.apache.hudi"            %% "hudi-spark3.4-bundle"      % V.hudi
   val iceberg      = "org.apache.iceberg"         %% "iceberg-spark-runtime-3.4" % V.iceberg
@@ -94,6 +95,17 @@ object Dependencies {
   val catsEffectTestkit = "org.typelevel" %% "cats-effect-testkit"        % V.catsEffect       % Test
   val catsEffectSpecs2  = "org.typelevel" %% "cats-effect-testing-specs2" % V.catsEffectSpecs2 % Test
 
+  val commonRuntimeDependencies = Seq(
+    delta        % Runtime,
+    hudi         % Runtime,
+    iceberg      % Runtime,
+    hadoopClient % Runtime,
+    slf4j        % Runtime,
+    protobuf     % Runtime,
+    sparkHive    % Runtime,
+    hiveExec     % Runtime // Needed for hudi
+  )
+
   val coreDependencies = Seq(
     streamsCore,
     loaders,
@@ -111,17 +123,7 @@ object Dependencies {
     catsEffectSpecs2,
     catsEffectTestkit,
     slf4j % Test
-  )
-
-  val commonRuntimeDependencies = Seq(
-    delta        % Runtime,
-    hudi         % Runtime,
-    iceberg      % Runtime,
-    hadoopClient % Runtime,
-    slf4j        % Runtime,
-    protobuf     % Runtime,
-    hiveExec     % Runtime // Needed for hudi
-  )
+  ) ++ commonRuntimeDependencies
 
   val awsDependencies = Seq(
     kinesis,


### PR DESCRIPTION
Before this PR, we had an integration test for Delta, but nothing for Iceberg and Hudi.

This helps with managing the project dependencies.  It is all too easy to exclude a runtime dependency and then find that loading has broken for one of the formats.