### PR TITLE
Change default log level of Delta libraries

### DIFF
--- a/modules/core/src/main/resources/simplelogger.properties
+++ b/modules/core/src/main/resources/simplelogger.properties
@@ -1,3 +1,4 @@
 org.slf4j.simpleLogger.defaultLogLevel=warn
 org.slf4j.simpleLogger.log.com.snowplowanalytics=info
 org.slf4j.simpleLogger.log.org.apache.spark.scheduler.TaskSetManager=error
+org.slf4j.simpleLogger.log.org.apache.spark.sql.delta=info


### PR DESCRIPTION
Before this change, the default log level for Delta is WARN. But that means we don't have much visibility in the logs of the granular steps that Delta runs to commit events to the lake.

This change bumps the log level to INFO for Delta only (other logger's are left un-changed).  This adds a modest number of extra lines to the log output.  Not overwhelming, but enough to be helpful.