### PR TITLE
Adjust default spark memory configuration

### DIFF
--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -54,9 +54,10 @@
       "spark.ui.enabled": "false"
       "spark.local.dir": "/tmp" # This is the default but it's important for us
       "spark.serializer": "org.apache.spark.serializer.KryoSerializer"
-      "spark.memory.fraction": "0.2" # Decreased from the Spark default to prevent OOMs
+      "spark.memory.fraction": "0.3" # Decreased from the Spark default to prevent OOMs
       "spark.sql.parquet.outputTimestampType": "TIMESTAMP_MICROS"
       "spark.sql.parquet.datetimeRebaseModeInWrite": "CORRECTED"
+      "spark.memory.storageFraction": "0"
     }
     "gcpUserAgent": ${gcpUserAgent}
   }


### PR DESCRIPTION
Refers to standard [spark configuration properties](https://spark.apache.org/docs/latest/configuration.html)

`spark.memory.fraction`: Adjusts how much memory we allow for Spark vs non-Spark parts of the loader. The Spark default is 0.6. I previously decreased this to 0.2 in the Lake Loader to avoid OOMs. But with the newer versions of Lake Loader I find 0.3 is also fine for avoiding OOMs. I found 0.3 works slightly better than 0.2 for committing events as the table size increases.

`spark.memory.storageFraction`: Fraction of the spark memory that is immune to eviction when under memory pressure. The Spark default is 0.5. But we can set it to "0" because this loader can tolerate evicted blocks, and doing so allows a bit more memory for the shuffle, which happens when committing events.