### PR TITLE
Fix and simplify BigLake as Iceberg catalog

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,6 @@ lazy val gcpBiglake: Project = gcp
   .withId("gcpBiglake")
   .settings(target := (biglake / target).value / "gcp")
   .settings(BuildSettings.biglakeAppSettings)
-  .dependsOn(hudi % "runtime->runtime")
+  .dependsOn(biglake % "runtime->runtime")
 
 ThisBuild / fork := true

--- a/config/config.gcp.reference.hocon
+++ b/config/config.gcp.reference.hocon
@@ -94,12 +94,6 @@
 #     # -- Name of the table in the biglake catalog (required)
 #     "table": "events"
 #
-#     # -- Name of the BigQuery connection, which has permissions to access the lake (required)
-#     "connection": "snowplow-connection"
-#
-#     # -- Name of the BigQuery dataset to contain the Iceberg BigLake table (required)
-#     "bqDataset": "snowplow"
-#
 #     # -- GCP Region where the BigLake resides (required)
 #     "region": "europe-west1"
 #

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
@@ -57,6 +57,7 @@ object Config {
   sealed trait Iceberg extends Target {
     def sparkDatabase: String
     def table: String
+    def location: URI
   }
 
   case class IcebergHadoop(
@@ -88,8 +89,6 @@ object Config {
     catalog: String,
     database: String,
     table: String,
-    connection: String,
-    bqDataset: String,
     region: String, // (of biglake) also known as location in biglake docs.
     location: URI
   ) extends Iceberg {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergBigLakeWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergBigLakeWriter.scala
@@ -25,11 +25,4 @@ class IcebergBigLakeWriter(config: Config.IcebergBigLake) extends IcebergWriter(
       s"spark.sql.catalog.$sparkCatalog.warehouse" -> config.location.toString
     )
 
-  override def extraTableProperties: Map[String, String] =
-    Map(
-      "bq_table" -> s"${config.bqDataset}.${config.table}",
-      "bq_connection" -> s"projects/${config.project}/locations/${config.region}/connections/${config.connection}"
-    )
-
-  override def requiresCreateNamespace: Boolean = true
 }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergHadoopWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergHadoopWriter.scala
@@ -12,7 +12,7 @@ package com.snowplowanalytics.snowplow.lakes.tables
 
 import com.snowplowanalytics.snowplow.lakes.Config
 
-class IcebergHadoopWriter(config: Config.IcebergHadoop) extends IcebergWriter.WithDefaults(config) {
+class IcebergHadoopWriter(config: Config.IcebergHadoop) extends IcebergWriter(config) {
   override def sparkConfig: Map[String, String] =
     Map(
       "spark.sql.extensions" -> "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergSnowflakeWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergSnowflakeWriter.scala
@@ -12,7 +12,7 @@ package com.snowplowanalytics.snowplow.lakes.tables
 
 import com.snowplowanalytics.snowplow.lakes.Config
 
-class IcebergSnowflakeWriter(config: Config.IcebergSnowflake) extends IcebergWriter.WithDefaults(config) {
+class IcebergSnowflakeWriter(config: Config.IcebergSnowflake) extends IcebergWriter(config) {
 
   override def sparkConfig: Map[String, String] =
     Map(


### PR DESCRIPTION
Before this PR, the BigLake integration did not work at all, because of a mistake in how we layer the sbt dependencies. This PR fixes that mistake.

The loader will no longer create the BigLake **database** during initialisation.  It is a better separation of concerns if the loader requires the database to exist before the loader first runs.  A user can manually create a BigLake database in advance e.g. [with terraform][1]. The loader still creates the table, but not the database.

The loader will no longer create the **BigQuery external table**.  It is better if the loader interacts only with BigLake, and does not require any permissions to interact with BigQuery.  A user can easily manually create the BigQuery external table by running:

```sql
CREATE EXTERNAL TABLE `<bq_dataset_name>.<bq_table_name>`
WITH CONNECTION `<region_name>.<connection_name>`
OPTIONS (
  format = 'ICEBERG',
  uris = ['blms://projects/<project_name>/locations/<region_name>/catalogs/<biglake_catalog_name>/databases/<biglake_database_name>/tables/<biglake_table_name>']
)
```

[1]: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/biglake_database