### PR TITLE
Fix crashing on invalid view name

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/SparkUtils.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/SparkUtils.scala
@@ -66,13 +66,13 @@ private[processing] object SparkUtils {
   ): F[DataFrameOnDisk] = {
     val count = rows.size
     for {
-      viewName <- Sync[F].delay(UUID.randomUUID.toString.replaceAll("-", ""))
+      viewName <- Sync[F].delay("v" + UUID.randomUUID.toString.replaceAll("-", ""))
       _ <- Logger[F].debug(s"Saving batch of $count events to local disk")
       _ <- Sync[F].blocking {
              spark
                .createDataFrame(rows.toList.asJava, schema)
                .coalesce(1)
-               .localCheckpoint() // REMOVE this line to use memory instead of disk
+               .localCheckpoint()
                .createTempView(viewName)
            }
     } yield DataFrameOnDisk(viewName, count)


### PR DESCRIPTION
On rare occasions I have seen the loader crash with an error coming from Spark:

```
Invalid view name: 63404654e22943188965751863018763.
```

On all occasions, I noticed the view name contained mainly numeric characters. This seems to be fixed by making the view name more obviously not-a-number.