### PR TITLE
Bump common-streams to 0.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val root = project
 lazy val core: Project = project
   .in(file("modules/core"))
   .settings(BuildSettings.commonSettings)
+  .settings(BuildSettings.igluTestSettings)
   .settings(libraryDependencies ++= Dependencies.coreDependencies)
 
 lazy val azure: Project = project
@@ -54,6 +55,7 @@ lazy val aws: Project = project
 lazy val hudi: Project = project
   .in(file("packaging/hudi"))
   .settings(BuildSettings.commonSettings)
+  .settings(BuildSettings.igluTestSettings)
   .settings(libraryDependencies ++= Dependencies.hudiDependencies)
   .dependsOn(core % "test->test")
 

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/Processing.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/Processing.scala
@@ -166,7 +166,7 @@ object Processing {
   private def rememberDataFrame[F[_]](ref: Ref[F, WindowState], dfOnDisk: DataFrameOnDisk): F[Unit] =
     ref.update(state => state.copy(framesOnDisk = dfOnDisk :: state.framesOnDisk))
 
-  private def rememberColumnNames[F[_]](ref: Ref[F, WindowState], fields: List[TypedTabledEntity]): F[Unit] = {
+  private def rememberColumnNames[F[_]](ref: Ref[F, WindowState], fields: Vector[TypedTabledEntity]): F[Unit] = {
     val colNames = fields.flatMap { typedTabledEntity =>
       typedTabledEntity.mergedField.name :: typedTabledEntity.recoveries.map(_._2.name)
     }.toSet

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/SparkCaster.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/SparkCaster.scala
@@ -10,6 +10,7 @@
 
 package com.snowplowanalytics.snowplow.lakes.processing
 
+import cats.data.NonEmptyVector
 import io.circe.Json
 
 import org.apache.spark.sql.Row
@@ -30,11 +31,11 @@ private[processing] object SparkCaster extends Caster[Any] {
   override def doubleValue(v: Double): Double    = v
   override def decimalValue(unscaled: BigInt, details: Type.Decimal): BigDecimal =
     BigDecimal(unscaled, details.scale)
-  override def timestampValue(v: Instant): Instant                = v
-  override def dateValue(v: LocalDate): LocalDate                 = v
-  override def arrayValue(vs: List[Any]): List[Any]               = vs
-  override def structValue(vs: List[Caster.NamedValue[Any]]): Row = row(vs)
+  override def timestampValue(v: Instant): Instant                          = v
+  override def dateValue(v: LocalDate): LocalDate                           = v
+  override def arrayValue(vs: Vector[Any]): Vector[Any]                     = vs
+  override def structValue(vs: NonEmptyVector[Caster.NamedValue[Any]]): Row = row(vs.toVector)
 
-  def row(vs: Seq[Caster.NamedValue[Any]]): Row = Row.fromSeq(vs.map(_.value))
+  def row(vs: Vector[Caster.NamedValue[Any]]): Row = Row.fromSeq(vs.map(_.value))
 
 }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/SparkSchema.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/SparkSchema.scala
@@ -22,11 +22,11 @@ object SparkSchema {
    *
    * The returned schema includes atomic fields and non-atomic fields but not the load_tstamp column
    */
-  private[processing] def forBatch(entities: List[TypedTabledEntity]): StructType = {
+  private[processing] def forBatch(entities: Vector[TypedTabledEntity]): StructType = {
     val nonAtomicFields = entities.flatMap { tte =>
       tte.mergedField :: tte.recoveries.map(_._2)
     }
-    StructType(atomic ::: nonAtomicFields.map(asSparkField))
+    StructType(atomic ++ nonAtomicFields.map(asSparkField))
   }
 
   /**
@@ -37,7 +37,7 @@ object SparkSchema {
    * @note
    *   this is a `val` not a `def` because we use it over and over again.
    */
-  val atomic: List[StructField] = AtomicFields.static.map(asSparkField)
+  val atomic: Vector[StructField] = AtomicFields.static.map(asSparkField)
 
   /** String representation of the atomic schema for creating a table using SQL dialiect */
   def ddlForCreate: String =
@@ -58,7 +58,7 @@ object SparkSchema {
     case Type.Decimal(precision, scale)     => DecimalType(Type.DecimalPrecision.toInt(precision), scale)
     case Type.Date                          => DateType
     case Type.Timestamp                     => TimestampType
-    case Type.Struct(fields)                => StructType(fields.map(asSparkField))
+    case Type.Struct(fields)                => StructType(fields.toVector.map(asSparkField))
     case Type.Array(element, elNullability) => ArrayType(fieldType(element), elNullability.nullable)
     case Type.Json                          => StringType // Spark does not support the `Json` parquet logical type.
   }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/DeltaWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/DeltaWriter.scala
@@ -100,11 +100,11 @@ class DeltaWriter(config: Config.Delta) extends Writer {
    *   The Delta config, whose `dataSkippingColumn` param tells us which columns must go first in
    *   the table definition. See Delta's data skipping feature to understand why.
    */
-  private def fieldsForCreate(config: Config.Delta): List[StructField] = {
+  private def fieldsForCreate(config: Config.Delta): Iterable[StructField] = {
     val (withStats, noStats) = AtomicFields.withLoadTstamp.partition { f =>
       config.dataSkippingColumns.contains(f.name)
     }
-    (withStats ::: noStats).map(SparkSchema.asSparkField)
+    (withStats ++ noStats).map(SparkSchema.asSparkField)
   }
 
 }

--- a/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/no-fields/jsonschema/1-0-0
+++ b/modules/core/src/test/resources/iglu-client-embedded/schemas/myvendor/no-fields/jsonschema/1-0-0
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "myvendor",
+    "name": "no-fields",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "additionalProperties": true
+}

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -20,6 +20,9 @@ import sbtdynver.DynVerPlugin.autoImport._
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 
+// Iglu plugin
+import com.snowplowanalytics.snowplow.sbt.IgluSchemaPlugin.autoImport._
+
 import scala.sys.process._
 
 object BuildSettings {
@@ -99,6 +102,13 @@ object BuildSettings {
       }
     },
     Compile / compile := ((Compile / compile) dependsOn downloadUnmanagedJars).value
+  )
+
+  val igluTestSettings = Seq(
+    Test / igluUris := Seq(
+      // Iglu Central schemas used in tests will get pre-fetched by sbt
+      "iglu:com.snowplowanalytics.snowplow.media/ad_break_end_event/jsonschema/1-0-0"
+    )
   )
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,15 +13,15 @@ object Dependencies {
 
   object V {
     // Scala
-    val catsEffect       = "3.5.0"
-    val catsRetry        = "3.1.0"
+    val catsEffect       = "3.5.4"
+    val catsRetry        = "3.1.3"
     val decline          = "2.4.1"
-    val circe            = "0.14.1"
-    val http4s           = "0.23.15"
+    val circe            = "0.14.3"
+    val http4s           = "0.23.16"
     val betterMonadicFor = "0.3.1"
 
     // Spark
-    val spark          = "3.4.1"
+    val spark          = "3.4.3"
     val delta          = "2.4.0"
     val hudi           = "0.14.0"
     val iceberg        = "1.3.1"
@@ -31,14 +31,14 @@ object Dependencies {
     val hive           = "3.1.3"
 
     // java
-    val slf4j    = "2.0.7"
-    val azureSdk = "1.11.1"
+    val slf4j    = "2.0.13"
+    val azureSdk = "1.11.4"
     val sentry   = "6.25.2"
     val awsSdk1  = "1.12.646"
-    val awsSdk2  = "2.20.43" // Match common-streams
+    val awsSdk2  = "2.25.16" // Match common-streams
 
     // Snowplow
-    val streams    = "0.5.0"
+    val streams    = "0.6.0"
     val igluClient = "3.0.0"
 
     // Transitive overrides
@@ -46,6 +46,12 @@ object Dependencies {
     val snappy   = "1.1.10.5"
     val thrift   = "0.18.1"
     val netty    = "4.1.104.Final"
+
+    /**
+     * The Lake Loader currently does not work with pubsub SDK versions later than 1.125.10. It
+     * appears to be an incompatibility in transitive dependencies, (e.g. grpc).
+     */
+    val pubsubSdk = "1.125.10"
 
     // tests
     val specs2           = "4.20.0"
@@ -87,7 +93,9 @@ object Dependencies {
   val thrift     = "org.apache.thrift"   % "libthrift"                          % V.thrift
   val netty      = "io.netty"            % "netty-all"                          % V.netty
   val awsBundle  = "com.amazonaws"       % "aws-java-sdk-bundle"                % V.awsSdk1
+  val pubsubSdk  = "com.google.cloud"    % "google-cloud-pubsub"                % V.pubsubSdk
 
+  // snowplow
   val streamsCore      = "com.snowplowanalytics" %% "streams-core"             % V.streams
   val kinesis          = "com.snowplowanalytics" %% "kinesis"                  % V.streams
   val kafka            = "com.snowplowanalytics" %% "kafka"                    % V.streams
@@ -146,7 +154,8 @@ object Dependencies {
   ) ++ commonRuntimeDependencies
 
   val gcpDependencies = Seq(
-    pubsub,
+    pubsub.exclude("com.google.cloud", "google-cloud-pubsub"),
+    pubsubSdk, // replace pubsub sdk with an earlier version
     gcsConnector
   ) ++ commonRuntimeDependencies
 


### PR DESCRIPTION
Snowplow users commonly use schemas with no nested fields. Previously, we were creating a string column and loading the string field `{}`. But there is no benefit to loading this redundant data.

By omitting a column for these schemas, it means we support schema evolution if the user ever adds a nested field to the empty schema.

For empty schemas with `additionalProperties: true` we retain the old behaviour of loading the original JSON as a string.