### PR TITLE
Bump spark and lake libraries to latest versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val core: Project = project
 lazy val azure: Project = project
   .in(file("modules/azure"))
   .settings(BuildSettings.azureSettings)
-  .settings(libraryDependencies ++= Dependencies.azureDependencies35 ++ Dependencies.spark35RuntimeDependencies)
+  .settings(libraryDependencies ++= Dependencies.azureDependencies ++ Dependencies.spark35RuntimeDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
 
@@ -46,7 +46,7 @@ lazy val gcp: Project = project
 lazy val aws: Project = project
   .in(file("modules/aws"))
   .settings(BuildSettings.awsSettings)
-  .settings(libraryDependencies ++= Dependencies.awsDependencies35 ++ Dependencies.spark35RuntimeDependencies)
+  .settings(libraryDependencies ++= Dependencies.awsDependencies ++ Dependencies.spark35RuntimeDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
 
@@ -76,7 +76,7 @@ lazy val awsHudi: Project = project
   .withId("awsHudi")
   .settings(BuildSettings.awsSettings ++ BuildSettings.hudiAppSettings)
   .settings(target := (hudi / target).value / "aws")
-  .settings(libraryDependencies ++= Dependencies.awsDependencies34)
+  .settings(libraryDependencies ++= Dependencies.awsDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
   .dependsOn(hudi % "runtime->runtime")
@@ -96,7 +96,7 @@ lazy val azureHudi: Project = project
   .withId("azureHudi")
   .settings(BuildSettings.azureSettings ++ BuildSettings.hudiAppSettings)
   .settings(target := (hudi / target).value / "azure")
-  .settings(libraryDependencies ++= Dependencies.azureDependencies34)
+  .settings(libraryDependencies ++= Dependencies.azureDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
   .dependsOn(hudi % "runtime->runtime")

--- a/build.sbt
+++ b/build.sbt
@@ -32,21 +32,21 @@ lazy val core: Project = project
 lazy val azure: Project = project
   .in(file("modules/azure"))
   .settings(BuildSettings.azureSettings)
-  .settings(libraryDependencies ++= Dependencies.azureDependencies)
+  .settings(libraryDependencies ++= Dependencies.azureDependencies35 ++ Dependencies.spark35RuntimeDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
 
 lazy val gcp: Project = project
   .in(file("modules/gcp"))
   .settings(BuildSettings.gcpSettings)
-  .settings(libraryDependencies ++= Dependencies.gcpDependencies)
+  .settings(libraryDependencies ++= Dependencies.gcpDependencies ++ Dependencies.spark35RuntimeDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
 
 lazy val aws: Project = project
   .in(file("modules/aws"))
   .settings(BuildSettings.awsSettings)
-  .settings(libraryDependencies ++= Dependencies.awsDependencies)
+  .settings(libraryDependencies ++= Dependencies.awsDependencies35 ++ Dependencies.spark35RuntimeDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
 
@@ -71,22 +71,34 @@ lazy val biglake: Project = project
  * with CVE management.
  */
 
-lazy val awsHudi: Project = aws
+lazy val awsHudi: Project = project
+  .in(file("modules/aws"))
   .withId("awsHudi")
+  .settings(BuildSettings.awsSettings ++ BuildSettings.hudiAppSettings)
   .settings(target := (hudi / target).value / "aws")
-  .settings(BuildSettings.hudiAppSettings)
+  .settings(libraryDependencies ++= Dependencies.awsDependencies34)
+  .dependsOn(core)
+  .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
   .dependsOn(hudi % "runtime->runtime")
 
-lazy val gcpHudi: Project = gcp
+lazy val gcpHudi: Project = project
+  .in(file("modules/gcp"))
   .withId("gcpHudi")
+  .settings(BuildSettings.gcpSettings ++ BuildSettings.hudiAppSettings)
   .settings(target := (hudi / target).value / "gcp")
-  .settings(BuildSettings.hudiAppSettings)
+  .settings(libraryDependencies ++= Dependencies.gcpDependencies)
+  .dependsOn(core)
+  .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
   .dependsOn(hudi % "runtime->runtime")
 
-lazy val azureHudi: Project = azure
+lazy val azureHudi: Project = project
+  .in(file("modules/azure"))
   .withId("azureHudi")
+  .settings(BuildSettings.azureSettings ++ BuildSettings.hudiAppSettings)
   .settings(target := (hudi / target).value / "azure")
-  .settings(BuildSettings.hudiAppSettings)
+  .settings(libraryDependencies ++= Dependencies.azureDependencies34)
+  .dependsOn(core)
+  .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
   .dependsOn(hudi % "runtime->runtime")
 
 lazy val gcpBiglake: Project = gcp

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,11 +21,12 @@ object Dependencies {
     val betterMonadicFor = "0.3.1"
 
     // Spark
-    val spark          = "3.4.3"
-    val delta          = "2.4.0"
+    val spark34        = "3.4.3"
+    val spark35        = "3.5.1"
+    val delta          = "3.2.0"
     val hudi           = "0.14.0"
-    val iceberg        = "1.3.1"
-    val hadoop         = "3.3.6"
+    val iceberg        = "1.5.1"
+    val hadoop         = "3.4.0"
     val gcsConnector   = "hadoop3-2.2.17"
     val biglakeIceberg = "0.1.0"
     val hive           = "3.1.3"
@@ -45,7 +46,7 @@ object Dependencies {
     val protobuf = "3.25.1"
     val snappy   = "1.1.10.5"
     val thrift   = "0.18.1"
-    val netty    = "4.1.104.Final"
+    val netty    = "4.1.109.Final"
 
     /**
      * The Lake Loader currently does not work with pubsub SDK versions later than 1.125.10. It
@@ -66,12 +67,14 @@ object Dependencies {
   val betterMonadicFor  = "com.olegpy"       %% "better-monadic-for"   % V.betterMonadicFor
 
   // spark and hadoop
-  val sparkCore    = "org.apache.spark"           %% "spark-core"                % V.spark
-  val sparkSql     = "org.apache.spark"           %% "spark-sql"                 % V.spark
-  val sparkHive    = "org.apache.spark"           %% "spark-hive"                % V.spark
-  val delta        = "io.delta"                   %% "delta-core"                % V.delta
+  val sparkCore35  = "org.apache.spark"           %% "spark-core"                % V.spark35
+  val sparkSql35   = "org.apache.spark"           %% "spark-sql"                 % V.spark35
+  val sparkCore34  = "org.apache.spark"           %% "spark-core"                % V.spark34
+  val sparkSql34   = "org.apache.spark"           %% "spark-sql"                 % V.spark34
+  val sparkHive34  = "org.apache.spark"           %% "spark-hive"                % V.spark34
+  val delta        = "io.delta"                   %% "delta-spark"               % V.delta
   val hudi         = "org.apache.hudi"            %% "hudi-spark3.4-bundle"      % V.hudi
-  val iceberg      = "org.apache.iceberg"         %% "iceberg-spark-runtime-3.4" % V.iceberg
+  val iceberg      = "org.apache.iceberg"         %% "iceberg-spark-runtime-3.5" % V.iceberg
   val hadoopClient = "org.apache.hadoop"           % "hadoop-client-runtime"     % V.hadoop
   val hadoopAzure  = "org.apache.hadoop"           % "hadoop-azure"              % V.hadoop
   val hadoopAws    = "org.apache.hadoop"           % "hadoop-aws"                % V.hadoop
@@ -110,8 +113,6 @@ object Dependencies {
   val catsEffectSpecs2  = "org.typelevel" %% "cats-effect-testing-specs2" % V.catsEffectSpecs2 % Test
 
   val commonRuntimeDependencies = Seq(
-    delta        % Runtime,
-    iceberg      % Runtime,
     hadoopClient % Runtime,
     slf4j        % Runtime,
     protobuf     % Runtime,
@@ -119,38 +120,65 @@ object Dependencies {
     snappy       % Runtime
   )
 
+  val spark35RuntimeDependencies = Seq(
+    delta       % Runtime,
+    iceberg     % Runtime,
+    sparkCore35 % Runtime,
+    sparkSql35  % Runtime
+  )
+
   val coreDependencies = Seq(
     streamsCore,
     loaders,
     runtime,
     catsRetry,
-    sparkCore,
-    sparkSql,
+    delta       % Provided,
+    sparkCore35 % Provided,
+    sparkSql35  % Provided,
+    iceberg     % Provided,
     igluClientHttp4s,
     blazeClient,
     decline,
     sentry,
     circeGenericExtra,
-    delta,
     specs2,
     catsEffectSpecs2,
     catsEffectTestkit,
     slf4j % Test
   ) ++ commonRuntimeDependencies
 
-  val awsDependencies = Seq(
+  val awsDependencies35 = Seq(
     kinesis,
     hadoopAws,
     awsBundle, // Dependency on aws sdk v1 will likely be removed in the next release of hadoop-aws
     awsGlue,
     awsS3,
-    awsSts
+    awsSts,
+    sparkCore35
   ) ++ commonRuntimeDependencies
 
-  val azureDependencies = Seq(
+  val awsDependencies34 = Seq(
+    kinesis,
+    hadoopAws,
+    awsBundle, // Dependency on aws sdk v1 will likely be removed in the next release of hadoop-aws
+    awsGlue,
+    awsS3,
+    awsSts,
+    sparkCore34
+  ) ++ commonRuntimeDependencies
+
+  val azureDependencies35 = Seq(
     kafka,
     azureIdentity,
-    hadoopAzure
+    hadoopAzure,
+    sparkCore35
+  ) ++ commonRuntimeDependencies
+
+  val azureDependencies34 = Seq(
+    kafka,
+    azureIdentity,
+    hadoopAzure,
+    sparkCore34
   ) ++ commonRuntimeDependencies
 
   val gcpDependencies = Seq(
@@ -166,8 +194,10 @@ object Dependencies {
   )
 
   val hudiDependencies = Seq(
-    hudi      % Runtime,
-    sparkHive % Runtime
+    hudi        % Runtime,
+    sparkCore34 % Runtime,
+    sparkSql34  % Runtime,
+    sparkHive34 % Runtime
   )
 
   val commonExclusions = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -147,38 +147,21 @@ object Dependencies {
     slf4j % Test
   ) ++ commonRuntimeDependencies
 
-  val awsDependencies35 = Seq(
+  val awsDependencies = Seq(
     kinesis,
     hadoopAws,
     awsBundle, // Dependency on aws sdk v1 will likely be removed in the next release of hadoop-aws
     awsGlue,
     awsS3,
     awsSts,
-    sparkCore35
+    hadoopClient
   ) ++ commonRuntimeDependencies
 
-  val awsDependencies34 = Seq(
-    kinesis,
-    hadoopAws,
-    awsBundle, // Dependency on aws sdk v1 will likely be removed in the next release of hadoop-aws
-    awsGlue,
-    awsS3,
-    awsSts,
-    sparkCore34
-  ) ++ commonRuntimeDependencies
-
-  val azureDependencies35 = Seq(
+  val azureDependencies = Seq(
     kafka,
     azureIdentity,
     hadoopAzure,
-    sparkCore35
-  ) ++ commonRuntimeDependencies
-
-  val azureDependencies34 = Seq(
-    kafka,
-    azureIdentity,
-    hadoopAzure,
-    sparkCore34
+    hadoopClient
   ) ++ commonRuntimeDependencies
 
   val gcpDependencies = Seq(


### PR DESCRIPTION
- Delta bumped to 3.2.0
- Iceberg bumped to 1.5.1
- Spark bumped to 3.5.1

The latest version of Hudi depends on Spark 3.4. So this commit also changes the sbt build so we can use different Spark versions in the different final assets.