### PR TITLE
feat: add IcebergCatalog rest support

### DIFF
--- a/config/config.aws.reference.hocon
+++ b/config/config.aws.reference.hocon
@@ -93,6 +93,7 @@
 #     # -- URI of the bucket where the data lake will be written (required)
 #     # -- For a S3 bucket, the uri should start with `s3a://`
 #     "location": "s3a://my-bucket/events
+#     # -- or set to the warehouse name if using a Rest catalog
 #
 #     # -- Name of the database in the catalog (required)
 #     "database": "snowplow"
@@ -104,9 +105,13 @@
 #     "catalog": {
 #
 #       # -- The catalog implementation.
-#       # -- Options are `Glue` for the AWS Glue catalog, or Hadoop.
+#       # -- Options are `Glue` for the AWS Glue catalog, Rest, or Hadoop.
 #       # -- Option, default Hadoop.
 #       "type": "Glue"
+#
+#       "type": "Rest"
+#         "uri": "http://localhost:8080"
+#         "credentials": "" # -- This can be blank if not required
 #
 #       # -- Any other valid catalog config option from the Iceberg documentation
 #       "options": {
@@ -114,6 +119,8 @@
 #          "glue.id": "123456789"
 #       }
 #     }
+     }
+
 #
 #     # -- Any valid Iceberg table property
 #     # -- This can be blank in most setups because the loader already sets sensible defaults.

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
@@ -87,6 +87,13 @@ object Config {
     case class Glue(
       options: Map[String, String]
     ) extends IcebergCatalog
+
+    case class Rest(
+      uri: String,
+      credential: String,
+      options: Map[String, String]
+    ) extends IcebergCatalog
+
   }
 
   case class GcpUserAgent(productName: String)

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergWriter.scala
@@ -94,6 +94,13 @@ class IcebergWriter(config: Config.Iceberg) extends Writer {
         Map(
           "catalog-impl" -> "org.apache.iceberg.aws.glue.GlueCatalog"
         ) ++ c.options
+      case c: Config.IcebergCatalog.Rest =>
+        Map(
+          "catalog-impl" -> "org.apache.iceberg.rest.RESTCatalog",
+          "uri" -> c.uri,
+          "credential" -> c.credential,
+          "warehouse" -> config.location.toString
+        ) ++ c.options
     }
 
   private def tableProps: String =


### PR DESCRIPTION
Added ability to lake loader to support writing to Iceberg tables managed by a rest-based catalog. Tested successfully with the Tabular implementation located at https://github.com/tabular-io/iceberg-rest-image and AWS S3. Should work with GCP and Azure too. Helps advance https://github.com/snowplow-incubator/snowplow-lake-loader/issues/22