### PR TITLE
Fix bad rows resizing

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/Processing.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/Processing.scala
@@ -237,8 +237,7 @@ object Processing {
     bad: List[BadRow]
   ): F[Unit] =
     if (bad.nonEmpty) {
-      val serialized = bad.map(_.compactByteArray)
-      bad.map(badRow => BadRowsSerializer.withMaxSize(badRow, badProcessor, env.badRowMaxSize))
+      val serialized = bad.map(badRow => BadRowsSerializer.withMaxSize(badRow, badProcessor, env.badRowMaxSize))
       env.metrics.addBad(bad.size) *>
         env.badSink.sinkSimple(ListOfList.of(List(serialized)))
     } else Applicative[F].unit


### PR DESCRIPTION
In #62 we added a feature so that bad rows are re-sized if their serialized length exceeds the maximum size allowed by the sink.

This fixes a bug which meant the resizing was not working properly.