### PR TITLE
Hudi loader should fail early if missing permissions on Glue catalog

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/SparkSchema.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/SparkSchema.scala
@@ -22,7 +22,7 @@ object SparkSchema {
    *
    * The returned schema includes atomic fields and non-atomic fields but not the load_tstamp column
    */
-  private[processing] def forBatch(entities: Vector[TypedTabledEntity], respectIgluNullability: Boolean): StructType = {
+  def forBatch(entities: Vector[TypedTabledEntity], respectIgluNullability: Boolean): StructType = {
     val nonAtomicFields = entities.flatMap { tte =>
       tte.mergedField :: tte.recoveries.map(_._2)
     }


### PR DESCRIPTION
It is possible to run the Hudi Lake Loader enabling the hudi option `"hoodie.datasource.hive_sync.enable": "true"` to register/sync the table to a Hive Metastore or Glue.

However, with that setting enabled, the Hudi delays syncing until the first time events are committed.  For use case, it is more helpful if the loader connects to Glue/Hive during startup, so we more quickly get an alert if the loader is missing permissions.

This PR works my making the loader add an empty commit during startup. It does not add any parquet file, but it triggers the loader to sync the table to Glue/Hive.