### PR TITLE
Implement alerting and retrying mechanisms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val aws: Project = project
   .in(file("modules/aws"))
   .settings(BuildSettings.awsSettings)
   .settings(libraryDependencies ++= Dependencies.awsDependencies ++ Dependencies.icebergDeltaRuntimeDependencies)
-  .dependsOn(core)
+  .dependsOn(core, deltaIceberg)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
 
 /** Packaging: Extra runtime dependencies for alternative assets * */
@@ -64,6 +64,11 @@ lazy val biglake: Project = project
   .settings(BuildSettings.commonSettings ++ BuildSettings.biglakeSettings)
   .settings(libraryDependencies ++= Dependencies.biglakeDependencies)
 
+lazy val deltaIceberg: Project = project
+  .in(file("packaging/delta-iceberg"))
+  .settings(BuildSettings.commonSettings)
+  .settings(libraryDependencies ++= Dependencies.icebergDeltaRuntimeDependencies)
+
 /**
  * Packaging: Alternative assets
  *
@@ -79,7 +84,7 @@ lazy val awsHudi: Project = project
   .settings(libraryDependencies ++= Dependencies.awsDependencies ++ Dependencies.hudiAwsDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
-  .dependsOn(hudi % "runtime->runtime")
+  .dependsOn(hudi % "runtime->runtime;compile->compile")
 
 lazy val gcpHudi: Project = project
   .in(file("modules/gcp"))

--- a/config/config.aws.reference.hocon
+++ b/config/config.aws.reference.hocon
@@ -181,6 +181,24 @@
     "writerParallelismFraction": 0.5
   }
 
+  # Retry configuration for lake operation failures
+  "retries": {
+
+    # -- Configures exponential backoff on errors related to how lake is set up for this loader.
+    # -- Examples include authentication errors and permissions errors.
+    # -- This class of errors are reported periodically to the monitoring webhook.
+    "setupErrors": {
+      "delay": "30 seconds"
+    }
+
+    # -- Configures exponential backoff errors that are likely to be transient.
+    # -- Examples include server errors and network errors
+    "transientErrors": {
+      "delay": "1 second"
+      "attempts": 5
+    }
+  }
+
   # -- Schemas that won't be loaded to the lake.  Optional, default value []
   "skipSchemas": [
     "iglu:com.acme/skipped1/jsonschema/1-0-0"
@@ -228,6 +246,16 @@
       # -- Map of key/value pairs to be included as tags
       "tags": {
         "myTag": "xyz"
+      }
+    }
+
+    # -- Report alerts to the webhook
+    "webhook": {
+      # An actual HTTP endpoint
+      "endpoint": "https://webhook.acme.com",
+      # Set of arbitrary key-value pairs attached to the payload
+      "tags": {
+        "pipeline": "production"
       }
     }
 

--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -152,6 +152,24 @@
     "writerParallelismFraction": 0.5
   }
 
+  # Retry configuration for lake operation failures
+  "retries": {
+
+    # -- Configures exponential backoff on errors related to how lake is set up for this loader.
+    # -- Examples include authentication errors and permissions errors.
+    # -- This class of errors are reported periodically to the monitoring webhook.
+    "setupErrors": {
+      "delay": "30 seconds"
+    }
+
+    # -- Configures exponential backoff errors that are likely to be transient.
+    # -- Examples include server errors and network errors
+    "transientErrors": {
+      "delay": "1 second"
+      "attempts": 5
+    }
+  }
+
   # -- Schemas that won't be loaded to the lake.  Optional, default value []
   "skipSchemas": [
     "iglu:com.acme/skipped1/jsonschema/1-0-0"
@@ -199,6 +217,16 @@
       # -- Map of key/value pairs to be included as tags
       "tags": {
         "myTag": "xyz"
+      }
+    }
+
+    # -- Report alerts to the webhook
+    "webhook": {
+      # An actual HTTP endpoint
+      "endpoint": "https://webhook.acme.com",
+      # Set of arbitrary key-value pairs attached to the payload
+      "tags": {
+        "pipeline": "production"
       }
     }
 

--- a/config/config.gcp.reference.hocon
+++ b/config/config.gcp.reference.hocon
@@ -160,6 +160,24 @@
     "writerParallelismFraction": 0.5
   }
 
+  # Retry configuration for lake operation failures
+  "retries": {
+
+    # -- Configures exponential backoff on errors related to how lake is set up for this loader.
+    # -- Examples include authentication errors and permissions errors.
+    # -- This class of errors are reported periodically to the monitoring webhook.
+    "setupErrors": {
+      "delay": "30 seconds"
+    }
+
+    # -- Configures exponential backoff errors that are likely to be transient.
+    # -- Examples include server errors and network errors
+    "transientErrors": {
+      "delay": "1 second"
+      "attempts": 5
+    }
+  }
+
   # -- Schemas that won't be loaded to the lake.  Optional, default value []
   "skipSchemas": [
     "iglu:com.acme/skipped1/jsonschema/1-0-0"
@@ -207,6 +225,16 @@
       # -- Map of key/value pairs to be included as tags
       "tags": {
         "myTag": "xyz"
+      }
+    }
+
+    # -- Report alerts to the webhook
+    "webhook": {
+      # An actual HTTP endpoint
+      "endpoint": "https://webhook.acme.com",
+      # Set of arbitrary key-value pairs attached to the payload
+      "tags": {
+        "pipeline": "production"
       }
     }
 

--- a/modules/azure/src/main/scala/com.snowplowanalytics.snowplow.lakes/AzureApp.scala
+++ b/modules/azure/src/main/scala/com.snowplowanalytics.snowplow.lakes/AzureApp.scala
@@ -34,4 +34,6 @@ object AzureApp extends LoaderApp[KafkaSourceConfig, KafkaSinkConfig](BuildInfo)
   override def source: SourceProvider = KafkaSource.build(_, classTag[SourceAuthHandler])
 
   override def badSink: SinkProvider = KafkaSink.resource(_, classTag[SinkAuthHandler])
+
+  override def isDestinationSetupError: DestinationSetupErrorCheck = _ => false
 }

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -127,6 +127,16 @@
     "writerParallelismFraction": 0.5
   }
 
+  "retries": {
+    "setupErrors": {
+      "delay": "30 seconds"
+    }
+    "transientErrors": {
+      "delay": "1 second"
+      "attempts": 5
+    }
+  }
+
   "skipSchemas": []
   "respectIgluNullability": true
 

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Alert.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Alert.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package com.snowplowanalytics.snowplow.lakes
+
+import cats.Show
+import cats.implicits.showInterpolator
+
+import com.snowplowanalytics.iglu.core.circe.implicits.igluNormalizeDataJson
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.snowplow.runtime.AppInfo
+
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+
+import java.sql.SQLException
+
+sealed trait Alert
+object Alert {
+
+  /** Restrict the length of an alert message to be compliant with alert iglu schema */
+  private val MaxAlertPayloadLength = 4096
+
+  final case class FailedToCreateEventsTable(cause: Throwable) extends Alert
+
+  def toSelfDescribingJson(
+    alert: Alert,
+    appInfo: AppInfo,
+    tags: Map[String, String]
+  ): Json =
+    SelfDescribingData(
+      schema = SchemaKey("com.snowplowanalytics.monitoring.loader", "alert", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      data = Json.obj(
+        "appName" -> appInfo.name.asJson,
+        "appVersion" -> appInfo.version.asJson,
+        "message" -> getMessage(alert).asJson,
+        "tags" -> tags.asJson
+      )
+    ).normalize
+
+  private def getMessage(alert: Alert): String = {
+    val full = alert match {
+      case FailedToCreateEventsTable(cause) => show"Failed to create events table: $cause"
+    }
+
+    full.take(MaxAlertPayloadLength)
+  }
+
+  private implicit def throwableShow: Show[Throwable] = {
+    def removeDuplicateMessages(in: List[String]): List[String] =
+      in match {
+        case h :: t :: rest =>
+          if (h.contains(t)) removeDuplicateMessages(h :: rest)
+          else if (t.contains(h)) removeDuplicateMessages(t :: rest)
+          else h :: removeDuplicateMessages(t :: rest)
+        case fewer => fewer
+      }
+
+    def accumulateMessages(t: Throwable): List[String] = {
+      val nextMessage = t match {
+        case t: SQLException => Some(s"${t.getMessage} = SqlState: ${t.getSQLState}")
+        case t               => Option(t.getMessage)
+      }
+      Option(t.getCause) match {
+        case Some(cause) => nextMessage.toList ::: accumulateMessages(cause)
+        case None        => nextMessage.toList
+      }
+    }
+
+    Show.show { t =>
+      removeDuplicateMessages(accumulateMessages(t)).mkString(": ")
+    }
+  }
+}

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/LoaderApp.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/LoaderApp.scala
@@ -41,8 +41,9 @@ abstract class LoaderApp[SourceConfig: Decoder, SinkConfig: Decoder](
 
   def source: SourceProvider
   def badSink: SinkProvider
+  def isDestinationSetupError: DestinationSetupErrorCheck
 
-  final def main: Opts[IO[ExitCode]] = Run.fromCli(info, source, badSink)
+  final def main: Opts[IO[ExitCode]] = Run.fromCli(info, source, badSink, isDestinationSetupError)
 
 }
 

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Monitoring.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Monitoring.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package com.snowplowanalytics.snowplow.lakes
+
+import cats.effect.{Resource, Sync}
+import cats.implicits._
+
+import com.snowplowanalytics.snowplow.runtime.AppInfo
+
+import org.http4s.circe.jsonEncoder
+import org.http4s.client.Client
+import org.http4s.{EntityDecoder, Method, Request}
+
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+trait Monitoring[F[_]] {
+  def alert(message: Alert): F[Unit]
+}
+
+object Monitoring {
+
+  private implicit def logger[F[_]: Sync]: Logger[F] = Slf4jLogger.getLogger[F]
+
+  def create[F[_]: Sync](
+    config: Option[Config.Webhook],
+    appInfo: AppInfo,
+    httpClient: Client[F]
+  )(implicit E: EntityDecoder[F, String]
+  ): Resource[F, Monitoring[F]] = Resource.pure {
+    new Monitoring[F] {
+
+      override def alert(message: Alert): F[Unit] =
+        config match {
+          case Some(webhookConfig) =>
+            val request = buildHttpRequest(webhookConfig, message)
+            Logger[F].info(show"Sending alert to ${webhookConfig.endpoint} with details of the setup error...") *>
+              executeHttpRequest(webhookConfig, httpClient, request)
+          case None =>
+            Logger[F].debug("Webhook monitoring is not configured, skipping alert")
+        }
+
+      def buildHttpRequest(webhookConfig: Config.Webhook, alert: Alert): Request[F] =
+        Request[F](Method.POST, webhookConfig.endpoint)
+          .withEntity(Alert.toSelfDescribingJson(alert, appInfo, webhookConfig.tags))
+
+      def executeHttpRequest(
+        webhookConfig: Config.Webhook,
+        httpClient: Client[F],
+        request: Request[F]
+      ): F[Unit] =
+        httpClient
+          .run(request)
+          .use { response =>
+            if (response.status.isSuccess) Sync[F].unit
+            else {
+              response
+                .as[String]
+                .flatMap(body => Logger[F].error(show"Webhook ${webhookConfig.endpoint} returned non-2xx response:\n$body"))
+            }
+          }
+          .handleErrorWith { e =>
+            Logger[F].error(e)(show"Webhook ${webhookConfig.endpoint} resulted in exception without a response")
+          }
+    }
+  }
+
+}

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/package.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/package.scala
@@ -12,4 +12,8 @@ package com.snowplowanalytics.snowplow
 
 package object lakes {
   type AnyConfig = Config[Any, Any]
+
+  // Type for the function that checks whether given exception
+  // is one of the destination setup errors
+  type DestinationSetupErrorCheck = Throwable => Boolean
 }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/Retrying.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/Retrying.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2014-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package com.snowplowanalytics.snowplow.lakes.processing
+
+import cats.Applicative
+import cats.effect.Sync
+import cats.implicits._
+
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import retry._
+import retry.implicits.retrySyntaxError
+
+import com.snowplowanalytics.snowplow.lakes.{Alert, AppHealth, Config, DestinationSetupErrorCheck, Monitoring}
+
+object Retrying {
+
+  private implicit def logger[F[_]: Sync]: Logger[F] = Slf4jLogger.getLogger[F]
+
+  def withRetries[F[_]: Sync: Sleep, A](
+    appHealth: AppHealth[F],
+    config: Config.Retries,
+    monitoring: Monitoring[F],
+    toAlert: Throwable => Alert,
+    destinationSetupErrorCheck: DestinationSetupErrorCheck
+  )(
+    action: F[A]
+  ): F[A] =
+    retryUntilSuccessful(appHealth, config, monitoring, toAlert, destinationSetupErrorCheck, action) <*
+      appHealth.setServiceHealth(AppHealth.Service.SparkWriter, isHealthy = true)
+
+  private def retryUntilSuccessful[F[_]: Sync: Sleep, A](
+    appHealth: AppHealth[F],
+    config: Config.Retries,
+    monitoring: Monitoring[F],
+    toAlert: Throwable => Alert,
+    destinationSetupErrorCheck: DestinationSetupErrorCheck,
+    action: F[A]
+  ): F[A] =
+    action
+      .onError(_ => appHealth.setServiceHealth(AppHealth.Service.SparkWriter, isHealthy = false))
+      .retryingOnSomeErrors(
+        isWorthRetrying = destinationSetupErrorCheck(_).pure[F],
+        policy          = policyForSetupErrors[F](config),
+        onError         = logErrorAndSendAlert[F](monitoring, toAlert, _, _)
+      )
+      .retryingOnAllErrors(
+        policy  = policyForTransientErrors[F](config),
+        onError = logError[F](_, _)
+      )
+
+  private def policyForSetupErrors[F[_]: Applicative](config: Config.Retries): RetryPolicy[F] =
+    RetryPolicies.exponentialBackoff[F](config.setupErrors.delay)
+
+  private def policyForTransientErrors[F[_]: Applicative](config: Config.Retries): RetryPolicy[F] =
+    RetryPolicies.fullJitter[F](config.transientErrors.delay).join(RetryPolicies.limitRetries(config.transientErrors.attempts - 1))
+
+  private def logErrorAndSendAlert[F[_]: Sync](
+    monitoring: Monitoring[F],
+    toAlert: Throwable => Alert,
+    error: Throwable,
+    details: RetryDetails
+  ): F[Unit] =
+    logError(error, details) *> monitoring.alert(toAlert(error))
+
+  private def logError[F[_]: Sync](error: Throwable, details: RetryDetails): F[Unit] =
+    Logger[F].error(error)(s"Executing command failed. ${extractRetryDetails(details)}")
+
+  private def extractRetryDetails(details: RetryDetails): String = details match {
+    case RetryDetails.GivingUp(totalRetries, totalDelay) =>
+      s"Giving up on retrying, total retries: $totalRetries, total delay: ${totalDelay.toSeconds} seconds"
+    case RetryDetails.WillDelayAndRetry(nextDelay, retriesSoFar, cumulativeDelay) =>
+      s"Will retry in ${nextDelay.toMillis} milliseconds, retries so far: $retriesSoFar, total delay so far: ${cumulativeDelay.toMillis} milliseconds"
+  }
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/LakeWriterSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/LakeWriterSpec.scala
@@ -13,13 +13,14 @@ package com.snowplowanalytics.snowplow.lakes.processing
 import cats.implicits._
 import cats.data.NonEmptyList
 import cats.effect.{IO, Ref}
+import cats.effect.testkit.TestControl
 import org.specs2.Specification
 import cats.effect.testing.specs2.CatsEffect
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.Row
 
 import com.snowplowanalytics.snowplow.runtime.HealthProbe
-import com.snowplowanalytics.snowplow.lakes.AppHealth
+import com.snowplowanalytics.snowplow.lakes._
 import com.snowplowanalytics.snowplow.sources.{EventProcessingConfig, EventProcessor, SourceAndAck}
 
 import scala.concurrent.duration.{DurationLong, FiniteDuration}
@@ -30,9 +31,12 @@ class LakeWriterSpec extends Specification with CatsEffect {
   def is = s2"""
   The lake writer should:
     become healthy after creating the table $e1
-    stay unhealthy after failure to create the table $e2
-    become healthy after committing to the lake $e3
-    become unhealthy after failure to commit to the lake $e4
+    retry adding columns and send alerts when there is a setup exception $e2
+    retry adding columns if there is a transient exception, with limited number of attempts and no monitoring alerts $e3
+    become healthy after recovering from an earlier setup error $e4
+    become healthy after recovering from an earlier transient error $e5
+    become healthy after committing to the lake $e6
+    become unhealthy after failure to commit to the lake $e7
   """
 
   def e1 =
@@ -41,7 +45,13 @@ class LakeWriterSpec extends Specification with CatsEffect {
         Action.CreateTableAttempted
       )
 
-      val wrappedLakeWriter = LakeWriter.withHandledErrors(c.lakeWriter, c.appHealth)
+      val wrappedLakeWriter = LakeWriter.withHandledErrors(
+        c.lakeWriter,
+        c.appHealth,
+        c.monitoring,
+        retriesConfig,
+        dummyDestinationSetupErrorCheck
+      )
 
       for {
         healthBefore <- c.appHealth.status
@@ -56,35 +66,154 @@ class LakeWriterSpec extends Specification with CatsEffect {
     }
 
   def e2 = {
-    val mocks = Mocks(List(Response.ExceptionThrown(new RuntimeException("boom!"))))
+    val mocks = Mocks(List.fill(100)(Response.ExceptionThrown(new RuntimeException("boom!"))))
     control(mocks).flatMap { c =>
       val expected = Vector(
+        Action.CreateTableAttempted,
+        Action.SentAlert(0L),
+        Action.CreateTableAttempted,
+        Action.SentAlert(30L),
+        Action.CreateTableAttempted,
+        Action.SentAlert(90L),
+        Action.CreateTableAttempted,
+        Action.SentAlert(210L)
+      )
+
+      val wrappedLakeWriter = LakeWriter.withHandledErrors(
+        c.lakeWriter,
+        c.appHealth,
+        c.monitoring,
+        retriesConfig,
+        _ => true
+      )
+
+      val test = for {
+        healthBefore <- c.appHealth.status
+        fiber <- wrappedLakeWriter.createTable.voidError.start
+        _ <- IO.sleep(4.minutes)
+        _ <- fiber.cancel
+        healthAfter <- c.appHealth.status
+        state <- c.state.get
+      } yield List(
+        state should beEqualTo(expected),
+        healthBefore should beUnhealthy,
+        healthAfter should beUnhealthy
+      ).reduce(_ and _)
+
+      TestControl.executeEmbed(test)
+    }
+  }
+
+  def e3 = {
+    val mocks = Mocks(List.fill(100)(Response.ExceptionThrown(new RuntimeException("boom!"))))
+    control(mocks).flatMap { c =>
+      val expected = Vector(
+        Action.CreateTableAttempted,
+        Action.CreateTableAttempted,
+        Action.CreateTableAttempted,
+        Action.CreateTableAttempted,
         Action.CreateTableAttempted
       )
 
-      val wrappedLakeWriter = LakeWriter.withHandledErrors(c.lakeWriter, c.appHealth)
+      val wrappedLakeWriter = LakeWriter.withHandledErrors(
+        c.lakeWriter,
+        c.appHealth,
+        c.monitoring,
+        retriesConfig,
+        _ => false
+      )
 
-      for {
+      val test = for {
         healthBefore <- c.appHealth.status
         _ <- wrappedLakeWriter.createTable.voidError
         healthAfter <- c.appHealth.status
         state <- c.state.get
       } yield List(
         state should beEqualTo(expected),
-        healthBefore should beAnInstanceOf[HealthProbe.Unhealthy],
-        healthAfter should beAnInstanceOf[HealthProbe.Unhealthy]
+        healthBefore should beUnhealthy,
+        healthAfter should beUnhealthy
       ).reduce(_ and _)
-    }
 
+      TestControl.executeEmbed(test)
+    }
   }
 
-  def e3 =
+  def e4 = {
+    val mocks = Mocks(List(Response.ExceptionThrown(new RuntimeException("boom!"))))
+    control(mocks).flatMap { c =>
+      val expected = Vector(
+        Action.CreateTableAttempted,
+        Action.SentAlert(0L),
+        Action.CreateTableAttempted
+      )
+
+      val wrappedLakeWriter = LakeWriter.withHandledErrors(
+        c.lakeWriter,
+        c.appHealth,
+        c.monitoring,
+        retriesConfig,
+        _ => true
+      )
+
+      val test = for {
+        healthBefore <- c.appHealth.status
+        _ <- wrappedLakeWriter.createTable.voidError
+        healthAfter <- c.appHealth.status
+        state <- c.state.get
+      } yield List(
+        state should beEqualTo(expected),
+        healthBefore should beUnhealthy,
+        healthAfter should beHealthy
+      ).reduce(_ and _)
+
+      TestControl.executeEmbed(test)
+    }
+  }
+
+  def e5 = {
+    val mocks = Mocks(List(Response.ExceptionThrown(new RuntimeException("boom!"))))
+    control(mocks).flatMap { c =>
+      val expected = Vector(
+        Action.CreateTableAttempted,
+        Action.CreateTableAttempted
+      )
+
+      val wrappedLakeWriter = LakeWriter.withHandledErrors(
+        c.lakeWriter,
+        c.appHealth,
+        c.monitoring,
+        retriesConfig,
+        _ => false
+      )
+
+      val test = for {
+        healthBefore <- c.appHealth.status
+        _ <- wrappedLakeWriter.createTable.voidError
+        healthAfter <- c.appHealth.status
+        state <- c.state.get
+      } yield List(
+        state should beEqualTo(expected),
+        healthBefore should beUnhealthy,
+        healthAfter should beHealthy
+      ).reduce(_ and _)
+
+      TestControl.executeEmbed(test)
+    }
+  }
+
+  def e6 =
     control().flatMap { c =>
       val expected = Vector(
         Action.CommitAttempted("testview")
       )
 
-      val wrappedLakeWriter = LakeWriter.withHandledErrors(c.lakeWriter, c.appHealth)
+      val wrappedLakeWriter = LakeWriter.withHandledErrors(
+        c.lakeWriter,
+        c.appHealth,
+        c.monitoring,
+        retriesConfig,
+        dummyDestinationSetupErrorCheck
+      )
 
       for {
         healthBefore <- c.appHealth.status
@@ -98,7 +227,7 @@ class LakeWriterSpec extends Specification with CatsEffect {
       ).reduce(_ and _)
     }
 
-  def e4 = {
+  def e7 = {
     val mocks = Mocks(List(Response.Success, Response.ExceptionThrown(new RuntimeException("boom!"))))
 
     control(mocks).flatMap { c =>
@@ -107,7 +236,13 @@ class LakeWriterSpec extends Specification with CatsEffect {
         Action.CommitAttempted("testview2")
       )
 
-      val wrappedLakeWriter = LakeWriter.withHandledErrors(c.lakeWriter, c.appHealth)
+      val wrappedLakeWriter = LakeWriter.withHandledErrors(
+        c.lakeWriter,
+        c.appHealth,
+        c.monitoring,
+        retriesConfig,
+        dummyDestinationSetupErrorCheck
+      )
 
       for {
         _ <- wrappedLakeWriter.commit("testview1")
@@ -123,6 +258,24 @@ class LakeWriterSpec extends Specification with CatsEffect {
     }
   }
 
+  /** Convenience matchers for health probe * */
+
+  def beHealthy: org.specs2.matcher.Matcher[HealthProbe.Status] = { (status: HealthProbe.Status) =>
+    val result = status match {
+      case HealthProbe.Healthy      => true
+      case HealthProbe.Unhealthy(_) => false
+    }
+    (result, s"$status is not healthy")
+  }
+
+  def beUnhealthy: org.specs2.matcher.Matcher[HealthProbe.Status] = { (status: HealthProbe.Status) =>
+    val result = status match {
+      case HealthProbe.Healthy      => false
+      case HealthProbe.Unhealthy(_) => true
+    }
+    (result, s"$status is not unhealthy")
+  }
+
 }
 
 object LakeWriterSpec {
@@ -131,6 +284,7 @@ object LakeWriterSpec {
   object Action {
     case object CreateTableAttempted extends Action
     case class CommitAttempted(viewName: String) extends Action
+    case class SentAlert(timeSentSeconds: Long) extends Action
   }
 
   sealed trait Response
@@ -144,7 +298,13 @@ object LakeWriterSpec {
   case class Control(
     state: Ref[IO, Vector[Action]],
     lakeWriter: LakeWriter[IO],
-    appHealth: AppHealth[IO]
+    appHealth: AppHealth[IO],
+    monitoring: Monitoring[IO]
+  )
+
+  val retriesConfig = Config.Retries(
+    Config.SetupErrorRetries(30.seconds),
+    Config.TransientErrorRetries(1.second, 5)
   )
 
   def control(mocks: Mocks = Mocks(Nil)): IO[Control] =
@@ -152,7 +312,7 @@ object LakeWriterSpec {
       state <- Ref[IO].of(Vector.empty[Action])
       appHealth <- testAppHealth
       tableManager <- testLakeWriter(state, mocks.lakeWriterResults)
-    } yield Control(state, tableManager, appHealth)
+    } yield Control(state, tableManager, appHealth, testMonitoring(state))
 
   private def testAppHealth: IO[AppHealth[IO]] = {
     val healthySource = new SourceAndAck[IO] {
@@ -166,6 +326,16 @@ object LakeWriterSpec {
       appHealth.setServiceHealth(AppHealth.Service.BadSink, isHealthy = true)
     }
   }
+
+  private def testMonitoring(state: Ref[IO, Vector[Action]]): Monitoring[IO] = new Monitoring[IO] {
+    def alert(message: Alert): IO[Unit] =
+      for {
+        now <- IO.realTime
+        _ <- state.update(_ :+ Action.SentAlert(now.toSeconds))
+      } yield ()
+  }
+
+  private val dummyDestinationSetupErrorCheck: Throwable => Boolean = _ => false
 
   private def testLakeWriter(state: Ref[IO, Vector[Action]], mocks: List[Response]): IO[LakeWriter[IO]] =
     for {

--- a/packaging/delta-iceberg/src/main/scala/com.snowplowanalytics.snowplow.lakes/TableFormatSetupError.scala
+++ b/packaging/delta-iceberg/src/main/scala/com.snowplowanalytics.snowplow.lakes/TableFormatSetupError.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2014-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package com.snowplowanalytics.snowplow.lakes
+
+import org.apache.iceberg.exceptions.{ForbiddenException => IcebergForbiddenException, NotFoundException => IcebergNotFoundException}
+
+object TableFormatSetupError {
+
+  // Check if given exception is specific to iceberg format
+  def check(t: Throwable): Boolean =
+    t match {
+      case _: IcebergNotFoundException =>
+        // Glue catalog does not exist
+        true
+      case _: IcebergForbiddenException =>
+        // No permission to create a table in Glue catalog
+        true
+      case _ =>
+        false
+    }
+}

--- a/packaging/hudi/src/main/scala/com.snowplowanalytics.snowplow.lakes/TableFormatSetupError.scala
+++ b/packaging/hudi/src/main/scala/com.snowplowanalytics.snowplow.lakes/TableFormatSetupError.scala
@@ -10,14 +10,9 @@
 
 package com.snowplowanalytics.snowplow.lakes
 
-import com.snowplowanalytics.snowplow.sources.pubsub.{PubsubSource, PubsubSourceConfig}
-import com.snowplowanalytics.snowplow.sinks.pubsub.{PubsubSink, PubsubSinkConfig}
+object TableFormatSetupError {
 
-object GcpApp extends LoaderApp[PubsubSourceConfig, PubsubSinkConfig](BuildInfo) {
-
-  override def source: SourceProvider = PubsubSource.build(_)
-
-  override def badSink: SinkProvider = PubsubSink.resource(_)
-
-  override def isDestinationSetupError: DestinationSetupErrorCheck = _ => false
+  // Check if given exception is specific to hudi format
+  // TODO: Implement it properly
+  def check: Throwable => Boolean = _ => false
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -140,8 +140,8 @@ object Dependencies {
   )
 
   val icebergDeltaRuntimeDependencies = Seq(
+    iceberg,
     delta                     % Runtime,
-    iceberg                   % Runtime,
     Spark.coreForIcebergDelta % Runtime,
     Spark.sqlForIcebergDelta  % Runtime
   )
@@ -170,8 +170,8 @@ object Dependencies {
     kinesis,
     hadoopAws.exclude("software.amazon.awssdk", "bundle"),
     awsCore, // Dependency on aws sdk v1 will likely be removed in the next release of hadoop-aws
-    awsGlue       % Runtime,
-    awsS3         % Runtime,
+    awsS3,
+    awsGlue,
     awsS3Transfer % Runtime,
     awsSts        % Runtime,
     hadoopClient


### PR DESCRIPTION
Jira ref: PDP-1321

Two features has been added in this PR: alerting and retrying

For alerting, webhook method is used similar to other Snowplow apps. Alert message is sent to URL given in the config. Alerts are sent for some error cases, not for all of them. In this PR, it is implemented such that it is sent only for setup errors. The error cases where alert sent can be extended in the future, of course. 

For retrying, two retry policies can be defined [similar to Snowflake Loader](https://github.com/snowplow-incubator/snowflake-loader/blob/main/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/SnowflakeRetrying.scala). One of them is for setup errors and other one is for transient errors. Alert would be sent only for setup errors, not for transient errors. 

Also, possible setup error cases for Iceberg/Glue/S3 are added in this PR as well. Error cases for other destinations/table formats will be added later.

One other thing I want to mention is changes on the dependencies and SBT packages. Some of the dependencies are switched from runtime to compile-time. This is done to be able to use exception classes in those dependencies in the project while trying to determine whether thrown exception is for one of the setup error cases or not. Also, new `iceberg` package is created to be able to use Iceberg specific exception classes while checking setup errors. 