### PR TITLE
Iceberg fail fast if missing permissions on the catalog

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/HudiWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/HudiWriter.scala
@@ -62,7 +62,7 @@ class HudiWriter(config: Config.Hudi) extends Writer {
         """)
       }.void *>
       // We make an empty commit during startup, so the loader can fail early if we are missing any permissions
-      write[F](spark.createDataFrame(List.empty[Row].asJava, SparkSchema.forBatch(Vector.empty, true)))
+      write[F](spark.createDataFrame(List.empty[Row].asJava, SparkSchema.structForCreate))
   }
 
   private def maybeCreateDatabase[F[_]: Sync](spark: SparkSession): F[Unit] =

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergWriter.scala
@@ -14,10 +14,12 @@ import cats.implicits._
 import cats.effect.Sync
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 
 import com.snowplowanalytics.snowplow.lakes.Config
 import com.snowplowanalytics.snowplow.lakes.processing.SparkSchema
+
+import scala.jdk.CollectionConverters._
 
 /**
  * A base [[Writer]] for all flavours of Iceberg. Different concrete classes support different types
@@ -50,7 +52,9 @@ class IcebergWriter(config: Config.Iceberg) extends Writer {
           TBLPROPERTIES($tableProps)
           $locationClause
         """)
-      }.void
+      }.void *>
+      // We make an empty commit during startup, so the loader can fail early if we are missing any permissions
+      write[F](spark.createDataFrame(List.empty[Row].asJava, SparkSchema.structForCreate))
 
   override def write[F[_]: Sync](df: DataFrame): F[Unit] =
     Sync[F].blocking {


### PR DESCRIPTION
The loader has a feature where it sends alerts to a webhook if the destination is mis-configured.

However, with Iceberg it was possible for the initialization to be successful, and yet the loader might still fail later while committing events, e.g. due to a permissions error updating the Glue catalog.

Here we add an extra step so the loader is forced to make an empty commit early during initialization.  If there is an error committing, then the loader sends a webhook alert and never becomes healthy.