### PR TITLE
Add option to exit on missing Iglu schemas

### DIFF
--- a/config/config.aws.reference.hocon
+++ b/config/config.aws.reference.hocon
@@ -207,6 +207,12 @@
     "iglu:com.acme/skipped4/jsonschema/*-*-*"
   ]
 
+  # -- Whether the loader should crash and exit if it fails to resolve an Iglu Schema.
+  # -- We recommend `true` because Snowplow enriched events have already passed validation, so a missing schema normally
+  # -- indicates an error that needs addressing.
+  # -- Change to `false` so events go the failed events stream instead of crashing the loader.
+  "exitOnMissingIgluSchema": true
+
   # -- Whether the output parquet files should declare nested fields as non-nullable according to the Iglu schema.
   # -- When true (default), nested fields are nullable only if they are not required fields according to the Iglu schema.
   # -- When false, all nested fields are defined as nullable in the output table's schemas

--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -178,6 +178,12 @@
     "iglu:com.acme/skipped4/jsonschema/*-*-*"
   ]
 
+  # -- Whether the loader should crash and exit if it fails to resolve an Iglu Schema.
+  # -- We recommend `true` because Snowplow enriched events have already passed validation, so a missing schema normally
+  # -- indicates an error that needs addressing.
+  # -- Change to `false` so events go the failed events stream instead of crashing the loader.
+  "exitOnMissingIgluSchema": true
+
   # -- Whether the output parquet files should declare nested fields as non-nullable according to the Iglu schema.
   # -- When true (default), nested fields are nullable only if they are not required fields according to the Iglu schema.
   # -- When false, all nested fields are defined as nullable in the output table's schemas

--- a/config/config.gcp.reference.hocon
+++ b/config/config.gcp.reference.hocon
@@ -186,6 +186,12 @@
     "iglu:com.acme/skipped4/jsonschema/*-*-*"
   ]
 
+  # -- Whether the loader should crash and exit if it fails to resolve an Iglu Schema.
+  # -- We recommend `true` because Snowplow enriched events have already passed validation, so a missing schema normally
+  # -- indicates an error that needs addressing.
+  # -- Change to `false` so events go the failed events stream instead of crashing the loader.
+  "exitOnMissingIgluSchema": true
+
   # -- Whether the output parquet files should declare nested fields as non-nullable according to the Iglu schema.
   # -- When true (default), nested fields are nullable only if they are not required fields according to the Iglu schema.
   # -- When false, all nested fields are defined as nullable in the output table's schemas

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -139,6 +139,7 @@
 
   "skipSchemas": []
   "respectIgluNullability": true
+  "exitOnMissingIgluSchema": true
 
   "monitoring": {
     "metrics": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
@@ -39,6 +39,7 @@ case class Config[+Source, +Sink](
   license: AcceptedLicense,
   skipSchemas: List[SchemaCriterion],
   respectIgluNullability: Boolean,
+  exitOnMissingIgluSchema: Boolean,
   retries: Config.Retries
 )
 

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Environment.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Environment.scala
@@ -53,7 +53,8 @@ case class Environment[F[_]](
   windowing: EventProcessingConfig.TimedWindows,
   badRowMaxSize: Int,
   schemasToSkip: List[SchemaCriterion],
-  respectIgluNullability: Boolean
+  respectIgluNullability: Boolean,
+  exitOnMissingIgluSchema: Boolean
 )
 
 object Environment {
@@ -82,20 +83,21 @@ object Environment {
       metrics <- Resource.eval(Metrics.build(config.main.monitoring.metrics))
       cpuParallelism = chooseCpuParallelism(config.main)
     } yield Environment(
-      appInfo                = appInfo,
-      source                 = sourceAndAck,
-      badSink                = badSink,
-      resolver               = resolver,
-      httpClient             = httpClient,
-      lakeWriter             = lakeWriterWrapped,
-      metrics                = metrics,
-      appHealth              = appHealth,
-      cpuParallelism         = cpuParallelism,
-      inMemBatchBytes        = config.main.inMemBatchBytes,
-      windowing              = windowing,
-      badRowMaxSize          = config.main.output.bad.maxRecordSize,
-      schemasToSkip          = config.main.skipSchemas,
-      respectIgluNullability = config.main.respectIgluNullability
+      appInfo                 = appInfo,
+      source                  = sourceAndAck,
+      badSink                 = badSink,
+      resolver                = resolver,
+      httpClient              = httpClient,
+      lakeWriter              = lakeWriterWrapped,
+      metrics                 = metrics,
+      appHealth               = appHealth,
+      cpuParallelism          = cpuParallelism,
+      inMemBatchBytes         = config.main.inMemBatchBytes,
+      windowing               = windowing,
+      badRowMaxSize           = config.main.output.bad.maxRecordSize,
+      schemasToSkip           = config.main.skipSchemas,
+      respectIgluNullability  = config.main.respectIgluNullability,
+      exitOnMissingIgluSchema = config.main.exitOnMissingIgluSchema
     )
 
   private def enableSentry[F[_]: Sync](appInfo: AppInfo, config: Option[Config.Sentry]): Resource[F, Unit] =

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/RuntimeService.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/RuntimeService.scala
@@ -15,9 +15,11 @@ sealed trait RuntimeService
 object RuntimeService {
   case object SparkWriter extends RuntimeService
   case object BadSink extends RuntimeService
+  case object Iglu extends RuntimeService
 
   implicit val show: Show[RuntimeService] = Show.show {
     case SparkWriter => "Spark writer"
     case BadSink     => "Failed events sink"
+    case Iglu        => "Iglu repositories"
   }
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/MockEnvironment.scala
@@ -76,20 +76,21 @@ object MockEnvironment {
       source = testSourceAndAck(windows, state)
     } yield {
       val env = Environment(
-        appInfo                = TestSparkEnvironment.appInfo,
-        source                 = source,
-        badSink                = testSink(state),
-        resolver               = Resolver[IO](Nil, None),
-        httpClient             = testHttpClient,
-        lakeWriter             = testLakeWriter(state),
-        metrics                = testMetrics(state),
-        appHealth              = testAppHealth(state),
-        inMemBatchBytes        = 1000000L,
-        cpuParallelism         = 1,
-        windowing              = EventProcessingConfig.TimedWindows(1.minute, 1.0, 1),
-        badRowMaxSize          = 1000000,
-        schemasToSkip          = List.empty,
-        respectIgluNullability = true
+        appInfo                 = TestSparkEnvironment.appInfo,
+        source                  = source,
+        badSink                 = testSink(state),
+        resolver                = Resolver[IO](Nil, None),
+        httpClient              = testHttpClient,
+        lakeWriter              = testLakeWriter(state),
+        metrics                 = testMetrics(state),
+        appHealth               = testAppHealth(state),
+        inMemBatchBytes         = 1000000L,
+        cpuParallelism          = 1,
+        windowing               = EventProcessingConfig.TimedWindows(1.minute, 1.0, 1),
+        badRowMaxSize           = 1000000,
+        schemasToSkip           = List.empty,
+        respectIgluNullability  = true,
+        exitOnMissingIgluSchema = false
       )
       MockEnvironment(state, env)
     }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/TestSparkEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/TestSparkEnvironment.scala
@@ -36,20 +36,21 @@ object TestSparkEnvironment {
     lakeWriter <- LakeWriter.build[IO](testConfig.spark, testConfig.output.good)
     lakeWriterWrapped = LakeWriter.withHandledErrors(lakeWriter, dummyAppHealth, retriesConfig, PartialFunction.empty)
   } yield Environment(
-    appInfo                = appInfo,
-    source                 = source,
-    badSink                = Sink[IO](_ => IO.unit),
-    resolver               = Resolver[IO](Nil, None),
-    httpClient             = testHttpClient,
-    lakeWriter             = lakeWriterWrapped,
-    metrics                = testMetrics,
-    appHealth              = dummyAppHealth,
-    inMemBatchBytes        = 1000000L,
-    cpuParallelism         = 1,
-    windowing              = EventProcessingConfig.TimedWindows(1.minute, 1.0, 1),
-    badRowMaxSize          = 1000000,
-    schemasToSkip          = List.empty,
-    respectIgluNullability = true
+    appInfo                 = appInfo,
+    source                  = source,
+    badSink                 = Sink[IO](_ => IO.unit),
+    resolver                = Resolver[IO](Nil, None),
+    httpClient              = testHttpClient,
+    lakeWriter              = lakeWriterWrapped,
+    metrics                 = testMetrics,
+    appHealth               = dummyAppHealth,
+    inMemBatchBytes         = 1000000L,
+    cpuParallelism          = 1,
+    windowing               = EventProcessingConfig.TimedWindows(1.minute, 1.0, 1),
+    badRowMaxSize           = 1000000,
+    schemasToSkip           = List.empty,
+    respectIgluNullability  = true,
+    exitOnMissingIgluSchema = false
   )
 
   private val retriesConfig = Config.Retries(

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/EventUtils.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/EventUtils.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package com.snowplowanalytics.snowplow.lakes.processing
+
+import cats.effect.IO
+
+import fs2.{Chunk, Stream}
+import com.snowplowanalytics.snowplow.sources.TokenedEvents
+import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
+import com.snowplowanalytics.snowplow.analytics.scalasdk.SnowplowEvent.{Contexts, UnstructEvent}
+
+import java.nio.charset.StandardCharsets
+import java.nio.ByteBuffer
+
+object EventUtils {
+
+  case class TestBatch(value: List[Event]) {
+    def tokened: IO[TokenedEvents] = {
+      val serialized = Chunk.from(value).map { e =>
+        StandardCharsets.UTF_8.encode(e.toTsv)
+      }
+      IO.unique.map { ack =>
+        TokenedEvents(serialized, ack, None)
+      }
+    }
+  }
+
+  def inputEvents(count: Long, source: IO[TestBatch]): IO[List[TestBatch]] =
+    Stream
+      .eval(source)
+      .repeat
+      .take(count)
+      .compile
+      .toList
+
+  def good(ue: UnstructEvent = UnstructEvent(None), contexts: Contexts = Contexts(List.empty)): IO[TestBatch] =
+    for {
+      eventId1 <- IO.randomUUID
+      eventId2 <- IO.randomUUID
+      collectorTstamp <- IO.realTimeInstant
+    } yield {
+      val event1 = Event
+        .minimal(eventId1, collectorTstamp, "0.0.0", "0.0.0")
+        .copy(tr_total = Some(1.23))
+        .copy(unstruct_event = ue)
+        .copy(contexts = contexts)
+      val event2 = Event
+        .minimal(eventId2, collectorTstamp, "0.0.0", "0.0.0")
+      TestBatch(List(event1, event2))
+    }
+
+  def badlyFormatted: IO[TokenedEvents] =
+    IO.unique.map { token =>
+      val serialized = Chunk("nonsense1", "nonsense2").map(s => ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8)))
+      TokenedEvents(serialized, token, None)
+    }
+
+}

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/ProcessingSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/ProcessingSpec.scala
@@ -10,23 +10,22 @@
 
 package com.snowplowanalytics.snowplow.lakes.processing
 
+import cats.implicits._
 import cats.effect.IO
-import fs2.{Chunk, Stream}
 import org.specs2.Specification
 import cats.effect.testing.specs2.CatsEffect
+import io.circe.Json
 import cats.effect.testkit.TestControl
 
-import java.nio.charset.StandardCharsets
 import java.time.Instant
 import scala.concurrent.duration.DurationLong
 
-import com.snowplowanalytics.snowplow.analytics.scalasdk.Event
-import com.snowplowanalytics.snowplow.lakes.MockEnvironment
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.snowplow.analytics.scalasdk.SnowplowEvent
+import com.snowplowanalytics.snowplow.lakes.{MockEnvironment, RuntimeService}
 import com.snowplowanalytics.snowplow.lakes.MockEnvironment.Action
-import com.snowplowanalytics.snowplow.sources.TokenedEvents
 
 class ProcessingSpec extends Specification with CatsEffect {
-  import ProcessingSpec._
 
   def is = s2"""
   The lake loader should:
@@ -36,12 +35,16 @@ class ProcessingSpec extends Specification with CatsEffect {
     Write multiple batches in a single window when batch exceeds cutoff $e4
     Write good batches and bad events when a window contains both $e5
     Set the latency metric based off the message timestamp $e6
+    Load events with a known schema $e7
+    Send failed events for an unrecognized schema $e8
+    Crash and exit for an unrecognized schema, if exitOnMissingIgluSchema is true $e9
   """
 
   def e1 = {
     val io = for {
-      inputs <- generateEvents.take(2).compile.toList
-      control <- MockEnvironment.build(List(inputs))
+      inputs <- EventUtils.inputEvents(2, EventUtils.good())
+      tokened <- inputs.traverse(_.tokened)
+      control <- MockEnvironment.build(List(tokened))
       _ <- Processing.stream(control.environment).compile.drain
       state <- control.state.get
     } yield state should beEqualTo(
@@ -55,7 +58,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000010"),
         Action.AddedCommittedCountMetric(4),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration),
-        Action.Checkpointed(inputs.map(_.ack)),
+        Action.Checkpointed(tokened.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000010")
       )
     )
@@ -65,8 +68,8 @@ class ProcessingSpec extends Specification with CatsEffect {
 
   def e2 = {
     val io = for {
-      inputs <- generateBadlyFormatted.take(3).compile.toList
-      control <- MockEnvironment.build(List(inputs))
+      tokened <- List.fill(3)(EventUtils.badlyFormatted).sequence
+      control <- MockEnvironment.build(List(tokened))
       _ <- Processing.stream(control.environment).compile.drain
       state <- control.state.get
     } yield state should beEqualTo(
@@ -83,7 +86,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.AddedReceivedCountMetric(2),
         Action.AddedBadCountMetric(2),
         Action.SentToBad(2),
-        Action.Checkpointed(inputs.map(_.ack)),
+        Action.Checkpointed(tokened.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000010")
       )
     )
@@ -93,9 +96,12 @@ class ProcessingSpec extends Specification with CatsEffect {
 
   def e3 = {
     val io = for {
-      window1 <- generateEvents.take(1).compile.toList
-      window2 <- generateEvents.take(3).compile.toList
-      window3 <- generateEvents.take(2).compile.toList
+      inputs1 <- EventUtils.inputEvents(1, EventUtils.good())
+      window1 <- inputs1.traverse(_.tokened)
+      inputs2 <- EventUtils.inputEvents(3, EventUtils.good())
+      window2 <- inputs2.traverse(_.tokened)
+      inputs3 <- EventUtils.inputEvents(2, EventUtils.good())
+      window3 <- inputs3.traverse(_.tokened)
       control <- MockEnvironment.build(List(window1, window2, window3))
       _ <- Processing.stream(control.environment).compile.drain
       state <- control.state.get
@@ -144,8 +150,9 @@ class ProcessingSpec extends Specification with CatsEffect {
 
   def e4 = {
     val io = for {
-      inputs <- generateEvents.take(3).compile.toList
-      control <- MockEnvironment.build(List(inputs))
+      inputs <- EventUtils.inputEvents(3, EventUtils.good())
+      tokened <- inputs.traverse(_.tokened)
+      control <- MockEnvironment.build(List(tokened))
       environment = control.environment.copy(inMemBatchBytes = 1L) // Drop the allowed max bytes
       _ <- Processing.stream(environment).compile.drain
       state <- control.state.get
@@ -163,7 +170,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000010"),
         Action.AddedCommittedCountMetric(6),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration),
-        Action.Checkpointed(inputs.map(_.ack)),
+        Action.Checkpointed(tokened.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000010")
       )
     )
@@ -173,10 +180,10 @@ class ProcessingSpec extends Specification with CatsEffect {
 
   def e5 = {
     val io = for {
-      bads1 <- generateBadlyFormatted.take(3).compile.toList
-      goods1 <- generateEvents.take(3).compile.toList
-      bads2 <- generateBadlyFormatted.take(1).compile.toList
-      goods2 <- generateEvents.take(1).compile.toList
+      bads1 <- List.fill(3)(EventUtils.badlyFormatted).sequence
+      goods1 <- EventUtils.inputEvents(3, EventUtils.good()).flatMap(_.traverse(_.tokened))
+      bads2 <- List.fill(1)(EventUtils.badlyFormatted).sequence
+      goods2 <- EventUtils.inputEvents(1, EventUtils.good()).flatMap(_.traverse(_.tokened))
       control <- MockEnvironment.build(List(bads1 ::: goods1 ::: bads2 ::: goods2))
       _ <- Processing.stream(control.environment).compile.drain
       state <- control.state.get
@@ -218,12 +225,13 @@ class ProcessingSpec extends Specification with CatsEffect {
     val processTime = Instant.parse("2023-10-24T10:00:42.123Z").minusMillis(MockEnvironment.TimeTakenToCreateTable.toMillis)
 
     val io = for {
-      inputs <- generateEvents.take(2).compile.toList.map {
-                  _.map {
-                    _.copy(earliestSourceTstamp = Some(messageTime))
-                  }
-                }
-      control <- MockEnvironment.build(List(inputs))
+      inputs <- EventUtils.inputEvents(2, EventUtils.good())
+      tokened <- inputs.traverse(_.tokened).map {
+                   _.map {
+                     _.copy(earliestSourceTstamp = Some(messageTime))
+                   }
+                 }
+      control <- MockEnvironment.build(List(tokened))
       _ <- IO.sleep(processTime.toEpochMilli.millis)
       _ <- Processing.stream(control.environment).compile.drain
       state <- control.state.get
@@ -240,40 +248,122 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v20231024100042"),
         Action.AddedCommittedCountMetric(4),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration),
-        Action.Checkpointed(inputs.map(_.ack)),
+        Action.Checkpointed(tokened.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v20231024100042")
       )
     )
 
     TestControl.executeEmbed(io)
   }
-}
 
-object ProcessingSpec {
+  def e7 = {
 
-  def generateEvents: Stream[IO, TokenedEvents] =
-    Stream.eval {
-      for {
-        ack <- IO.unique
-        eventId1 <- IO.randomUUID
-        eventId2 <- IO.randomUUID
-        collectorTstamp <- IO.realTimeInstant
-      } yield {
-        val event1 = Event.minimal(eventId1, collectorTstamp, "0.0.0", "0.0.0")
-        val event2 = Event.minimal(eventId2, collectorTstamp, "0.0.0", "0.0.0")
-        val serialized = Chunk(event1, event2).map { e =>
-          StandardCharsets.UTF_8.encode(e.toTsv)
-        }
-        TokenedEvents(serialized, ack, None)
-      }
-    }.repeat
+    val ueGood700 = SnowplowEvent.UnstructEvent(
+      Some(
+        SelfDescribingData(
+          SchemaKey("myvendor", "goodschema", "jsonschema", SchemaVer.Full(7, 0, 0)),
+          Json.obj(
+            "col_a" -> Json.fromString("xyz")
+          )
+        )
+      )
+    )
 
-  def generateBadlyFormatted: Stream[IO, TokenedEvents] =
-    Stream.eval {
-      IO.unique.map { token =>
-        val serialized = Chunk("nonsense1", "nonsense2").map(StandardCharsets.UTF_8.encode(_))
-        TokenedEvents(serialized, token, None)
-      }
-    }.repeat
+    val io = for {
+      inputs <- EventUtils.inputEvents(1, EventUtils.good(ue = ueGood700))
+      tokened <- inputs.traverse(_.tokened)
+      control <- MockEnvironment.build(List(tokened))
+      _ <- Processing.stream(control.environment).compile.drain
+      state <- control.state.get
+    } yield state should beEqualTo(
+      Vector(
+        Action.SubscribedToStream,
+        Action.CreatedTable,
+        Action.InitializedLocalDataFrame("v19700101000010"),
+        Action.AddedReceivedCountMetric(2),
+        Action.AppendedRowsToDataFrame("v19700101000010", 2),
+        Action.CommittedToTheLake("v19700101000010"),
+        Action.AddedCommittedCountMetric(2),
+        Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration),
+        Action.Checkpointed(tokened.map(_.ack)),
+        Action.RemovedDataFrameFromDisk("v19700101000010")
+      )
+    )
+
+    TestControl.executeEmbed(io)
+  }
+
+  def e8 = {
+
+    val ueDoesNotExist = SnowplowEvent.UnstructEvent(
+      Some(
+        SelfDescribingData(
+          SchemaKey("myvendor", "doesnotexit", "jsonschema", SchemaVer.Full(7, 0, 0)),
+          Json.obj(
+            "col_a" -> Json.fromString("xyz")
+          )
+        )
+      )
+    )
+
+    val io = for {
+      inputs <- EventUtils.inputEvents(1, EventUtils.good(ue = ueDoesNotExist))
+      tokened <- inputs.traverse(_.tokened)
+      control <- MockEnvironment.build(List(tokened))
+      _ <- Processing.stream(control.environment).compile.drain
+      state <- control.state.get
+    } yield state should beEqualTo(
+      Vector(
+        Action.SubscribedToStream,
+        Action.CreatedTable,
+        Action.InitializedLocalDataFrame("v19700101000010"),
+        Action.AddedReceivedCountMetric(2),
+        Action.AddedBadCountMetric(1),
+        Action.SentToBad(1),
+        Action.AppendedRowsToDataFrame("v19700101000010", 1),
+        Action.CommittedToTheLake("v19700101000010"),
+        Action.AddedCommittedCountMetric(1),
+        Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration),
+        Action.Checkpointed(tokened.map(_.ack)),
+        Action.RemovedDataFrameFromDisk("v19700101000010")
+      )
+    )
+
+    TestControl.executeEmbed(io)
+  }
+
+  def e9 = {
+
+    val ueDoesNotExist = SnowplowEvent.UnstructEvent(
+      Some(
+        SelfDescribingData(
+          SchemaKey("myvendor", "doesnotexit", "jsonschema", SchemaVer.Full(7, 0, 0)),
+          Json.obj(
+            "col_a" -> Json.fromString("xyz")
+          )
+        )
+      )
+    )
+
+    val io = for {
+      inputs <- EventUtils.inputEvents(1, EventUtils.good(ue = ueDoesNotExist))
+      tokened <- inputs.traverse(_.tokened)
+      control <- MockEnvironment.build(List(tokened))
+      environment = control.environment.copy(exitOnMissingIgluSchema = true)
+      _ <- Processing.stream(environment).compile.drain.voidError
+      state <- control.state.get
+    } yield state should beEqualTo(
+      Vector(
+        Action.SubscribedToStream,
+        Action.CreatedTable,
+        Action.InitializedLocalDataFrame("v19700101000010"),
+        Action.AddedReceivedCountMetric(2),
+        Action.BecameUnhealthy(RuntimeService.Iglu),
+        Action.RemovedDataFrameFromDisk("v19700101000010")
+      )
+    )
+
+    TestControl.executeEmbed(io)
+  }
 
 }


### PR DESCRIPTION
Before this PR, the loader would generate a failed event if it failed to fetch a required schema from Iglu.  However, all events have already passed validation in Enrich, so it is completely unexpected to have an Iglu failure.  An Iglu error _probably_ means some type of configuration error or service outage.

After this PR, the loader will crash and exit on an Iglu error, instead of creating a failed event.  This is probably the preferred behaviour, while the pipeline operator addresses the underlying infrastructure problem.

If an Iglu schema is genuinely now unavailable, then the pipeline operator can override the default behaviour by setting `exitOnMissingFailure: false` in the configuration file or by listing the missing schema in `skipschemas`.