### PR TITLE
common-streams 0.8.x with refactored kinesis source

### DIFF
--- a/config/config.aws.reference.hocon
+++ b/config/config.aws.reference.hocon
@@ -34,10 +34,6 @@
       "maxRecords": 1000
     }
 
-    # -- The number of batches of events which are pre-fetched from kinesis.
-    # -- Increasing this above 1 is not known to improve performance.
-    "bufferSize": 3
-
     # -- Name of this KCL worker used in the dynamodb lease table
     "workerIdentifier": ${HOSTNAME}
 
@@ -218,6 +214,13 @@
   # -- When false, all nested fields are defined as nullable in the output table's schemas
   # -- Set this to false if you use a query engine that dislikes non-nullable nested fields of a nullable struct.
   "respectIgluNullability": true
+
+  # -- Configuration of internal http client used for iglu resolver, alerts and telemetry
+  "http": {
+    "client": {
+      "maxConnectionsPerServer": 4
+    }
+  }
 
   "monitoring": {
     "metrics": {

--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -190,6 +190,13 @@
   # -- Set this to false if you use a query engine that dislikes non-nullable nested fields of a nullable struct.
   "respectIgluNullability": true
 
+  # -- Configuration of internal http client used for iglu resolver, alerts and telemetry
+  "http": {
+    "client": {
+      "maxConnectionsPerServer": 4
+    }
+  }
+
   "monitoring": {
     "metrics": {
 

--- a/config/config.gcp.reference.hocon
+++ b/config/config.gcp.reference.hocon
@@ -198,6 +198,13 @@
   # -- Set this to false if you use a query engine that dislikes non-nullable nested fields of a nullable struct.
   "respectIgluNullability": true
 
+  # -- Configuration of internal http client used for iglu resolver, alerts and telemetry
+  "http": {
+    "client": {
+      "maxConnectionsPerServer": 4
+    }
+  }
+
   "monitoring": {
     "metrics": {
 

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -137,6 +137,10 @@
     }
   }
 
+  "http": {
+    "client": ${snowplow.defaults.http.client}
+  }
+
   "skipSchemas": []
   "respectIgluNullability": true
   "exitOnMissingIgluSchema": true

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,8 +50,8 @@ object Dependencies {
     val awsRegistry = "1.1.20"
 
     // Snowplow
-    val streams    = "0.8.0-M2"
-    val igluClient = "3.0.0"
+    val streams    = "0.8.0-M4"
+    val igluClient = "3.2.0"
 
     // Transitive overrides
     val protobuf = "3.25.1"
@@ -71,7 +71,6 @@ object Dependencies {
 
   }
 
-  val blazeClient       = "org.http4s"   %% "http4s-blaze-client"  % V.http4s
   val decline           = "com.monovore" %% "decline-effect"       % V.decline
   val circeGenericExtra = "io.circe"     %% "circe-generic-extras" % V.circe
   val betterMonadicFor  = "com.olegpy"   %% "better-monadic-for"   % V.betterMonadicFor
@@ -153,7 +152,6 @@ object Dependencies {
     Spark.sqlForIcebergDelta  % Provided,
     iceberg                   % Provided,
     igluClientHttp4s,
-    blazeClient,
     decline,
     sentry,
     circeGenericExtra,
@@ -170,7 +168,7 @@ object Dependencies {
     awsS3,
     awsGlue,
     awsS3Transfer % Runtime,
-    awsSts        % Runtime,
+    awsSts,
     hadoopClient
   ) ++ commonRuntimeDependencies
 


### PR DESCRIPTION
The following improvements are introduced via common-streams 0.8.0-M4:

- Fields starting with a digit are now prefixed with an underscore `_`.  This is needed for Hudi, which does not allow fields starting with a digit (https://github.com/snowplow/schema-ddl/pull/209)
- New kinesis source implementation without fs2-kinesis (https://github.com/snowplow-incubator/common-streams/pull/84)
- Iglu schemas are resolved in parallel, for short pause times during event processing (https://github.com/snowplow-incubator/common-streams/pull/85)
- Common http client configured with restricted max connections per server (https://github.com/snowplow-incubator/common-streams/pull/87)
- Iglu scala client 3.2.0 no longer relies on the "list" schemas endpoint (https://github.com/snowplow/iglu-scala-client/pull/255)