### PR TITLE
AssumedRoleCredentialsProvider for Delta DynamoDB log store

### DIFF
--- a/modules/aws/src/main/resources/application.conf
+++ b/modules/aws/src/main/resources/application.conf
@@ -19,6 +19,7 @@
       "fs.s3a.aws.credentials.provider": "com.snowplowanalytics.snowplow.lakes.AssumedRoleCredentialsProvider"
       "fs.s3a.assumed.role.session.name": "snowplow-lake-loader"
       "fs.s3a.assumed.role.session.duration": "1h"
+      "spark.io.delta.storage.S3DynamoDBLogStore.credentials.provider": "com.snowplowanalytics.snowplow.lakes.AssumedRoleCredentialsProviderV1"
     }
   }
 }

--- a/modules/aws/src/main/scala/com.snowplowanalytics.snowplow.lakes/AssumedRoleCredentialsProvider.scala
+++ b/modules/aws/src/main/scala/com.snowplowanalytics.snowplow.lakes/AssumedRoleCredentialsProvider.scala
@@ -44,7 +44,16 @@ import java.util.concurrent.TimeUnit
 class AssumedRoleCredentialsProvider(delegate: AwsCredentialsProvider) extends AwsCredentialsProvider {
 
   /**
-   * Standard constructor invoked by hadoop
+   * Standard constructor invoked by Delta for the LogStore (e.g. DynamoDB)
+   *
+   * @param conf
+   *   The hadoop configuration, provided via spark configuration
+   */
+  def this(conf: Configuration) =
+    this(AssumedRoleCredentialsProvider.getDelegate(conf))
+
+  /**
+   * Standard constructor invoked by hadoop for the filesystem
    *
    * @param fsUri
    *   Base URI of this filesystem (not used by us)
@@ -52,7 +61,7 @@ class AssumedRoleCredentialsProvider(delegate: AwsCredentialsProvider) extends A
    *   The hadoop configuration, provided via spark configuration
    */
   def this(fsUri: URI, conf: Configuration) =
-    this(AssumedRoleCredentialsProvider.getDelegate(conf))
+    this(conf)
 
   override def resolveCredentials(): AwsCredentials =
     delegate.resolveCredentials()

--- a/modules/aws/src/main/scala/com.snowplowanalytics.snowplow.lakes/AssumedRoleCredentialsProviderV1.scala
+++ b/modules/aws/src/main/scala/com.snowplowanalytics.snowplow.lakes/AssumedRoleCredentialsProviderV1.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2014-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package com.snowplowanalytics.snowplow.lakes
+
+import org.apache.hadoop.conf.Configuration
+import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, AWSSessionCredentials}
+import software.amazon.awssdk.auth.credentials.{AwsSessionCredentials => AwsSessionCredentialsV2}
+
+/**
+ * A credentials provider that delegates to the AWS SDK v2 provider
+ *
+ * Delta still uses the v1 SDK for authentication to the DynamoDB log store
+ */
+class AssumedRoleCredentialsProviderV1(delegate: AssumedRoleCredentialsProvider) extends AWSCredentialsProvider {
+
+  def this(conf: Configuration) =
+    this(new AssumedRoleCredentialsProvider(conf))
+
+  override def getCredentials(): AWSCredentials =
+    delegate.resolveCredentials() match {
+      case v2: AwsSessionCredentialsV2 =>
+        new AWSSessionCredentials {
+          def getAWSAccessKeyId() = v2.accessKeyId()
+          def getAWSSecretKey()   = v2.secretAccessKey()
+          def getSessionToken()   = v2.sessionToken()
+        }
+      case v2 =>
+        new AWSCredentials {
+          def getAWSAccessKeyId() = v2.accessKeyId()
+          def getAWSSecretKey()   = v2.secretAccessKey()
+        }
+    }
+
+  override def refresh(): Unit = ()
+
+}


### PR DESCRIPTION
The loader already has a custom credentials provider for use with the S3a filesystem, see #35

This commit adds a new constructor, which means the same provider can be used for the Delta DynamoDB log store.