### PR TITLE
Enable Iceberg's fan-out writer

### DIFF
--- a/config/config.aws.reference.hocon
+++ b/config/config.aws.reference.hocon
@@ -116,6 +116,12 @@
 #     "icebergTableProperties": {
 #       "write.metadata.metrics.column.event_id": "count"
 #     }
+#
+#     # -- Any valid Iceberg write option
+#     # -- This can be blank in most setups because the loader already sets sensible defaults.
+#     "icebergWriteOptions": {
+#       "write-format": "parquet"
+#     }
 #   }
 
     "bad": {

--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -94,6 +94,12 @@
 #     "icebergTableProperties": {
 #       "write.metadata.metrics.column.event_id": "count"
 #     }
+#
+#     # -- Any valid Iceberg write option
+#     # -- This can be blank in most setups because the loader already sets sensible defaults.
+#     "icebergWriteOptions": {
+#       "write-format": "parquet"
+#     }
 #   }
 
     "bad": {

--- a/config/config.gcp.reference.hocon
+++ b/config/config.gcp.reference.hocon
@@ -109,6 +109,12 @@
 #     "icebergTableProperties": {
 #       "write.metadata.metrics.column.event_id": "count"
 #     }
+#
+#     # -- Any valid Iceberg write option
+#     # -- This can be blank in most setups because the loader already sets sensible defaults.
+#     "icebergWriteOptions": {
+#       "write-format": "parquet"
+#     }
 #   }
 
     "bad": {

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -41,6 +41,13 @@
         "write.metadata.metrics.column.true_tstamp": "full"
       }
 
+      "icebergWriteOptions": {
+        "merge-schema": "true"
+        "check-ordering": "false"
+        "fanout-enabled": "true"
+        "distribution-mode": "none"
+      }
+
       "hudiTableProperties": {
         "hoodie.table.name": "events"
         "hoodie.table.keygenerator.class": "org.apache.hudi.keygen.TimestampBasedKeyGenerator"

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/Config.scala
@@ -74,7 +74,8 @@ object Config {
     table: String,
     catalog: IcebergCatalog,
     location: URI,
-    icebergTableProperties: Map[String, String]
+    icebergTableProperties: Map[String, String],
+    icebergWriteOptions: Map[String, String]
   ) extends Target
 
   sealed trait IcebergCatalog

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergWriter.scala
@@ -61,8 +61,7 @@ class IcebergWriter(config: Config.Iceberg) extends Writer {
       df.write
         .format("iceberg")
         .mode("append")
-        .option("merge-schema", true)
-        .option("check-ordering", false)
+        .options(config.icebergWriteOptions)
         .saveAsTable(fqTable)
     }
 


### PR DESCRIPTION
Previously, we were using the hash Iceberg [write distribution mode][1], because it is the default for Iceberg. The hash mode does an extra shuffle before writing. We found that that the write phase of the Lake Loader was too slow when under high load (Iceberg only): specifically, a write was taking longer than the loader's "window", and this caused periods of low cpu usage, where the loader's processing phase was waiting for the write phase to catch up.

This commit changes to the "none" write distribution mode, and the fan-out writer.  This removes the need for any spark shuffle task, and so the loader's write phase should be faster.

This change makes Iceberg writes behave more similar to Delta writes: In both cases the underlying writer runs a spark task which reads an un-sorted spark dataframe and fans-out to multiple output partitions in parallel. It is helpful for Lake Loader development to have a similar writing model across both formats.

[1]: https://iceberg.apache.org/docs/1.7.1/spark-writes/#writing-distribution-modes