### PR TITLE
Add end-to-end latency metric

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/WindowState.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/WindowState.scala
@@ -32,12 +32,15 @@ import java.time.{Instant, ZoneOffset}
  *   Names of the columns which will be written out by the loader
  * @param numEvents
  *   The number of events in this window
+ * @param earliestCollectorTstamp
+ *   The earliest collector_tstamp of all events seen in the window
  */
 private[processing] case class WindowState(
   tokens: List[Unique.Token],
   startTime: Instant,
   nonAtomicColumnNames: Set[String],
-  numEvents: Int
+  numEvents: Int,
+  earliestCollectorTstamp: Option[Instant]
 ) {
 
   /** The name by which the current DataFrame is known to the Spark catalog */
@@ -54,6 +57,6 @@ private[processing] object WindowState {
 
   def build[F[_]: Sync]: F[WindowState] =
     Sync[F].realTimeInstant.map { now =>
-      WindowState(Nil, now, Set.empty, 0)
+      WindowState(Nil, now, Set.empty, 0, None)
     }
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/MockEnvironment.scala
@@ -54,6 +54,7 @@ object MockEnvironment {
     case class AddedCommittedCountMetric(count: Int) extends Action
     case class SetLatencyMetric(latency: FiniteDuration) extends Action
     case class SetProcessingLatencyMetric(latency: FiniteDuration) extends Action
+    case class SetE2ELatencyMetric(latency: FiniteDuration) extends Action
 
     /* Health */
     case class BecameUnhealthy(service: RuntimeService) extends Action
@@ -159,6 +160,9 @@ object MockEnvironment {
 
     def setProcessingLatency(latency: FiniteDuration): IO[Unit] =
       ref.update(_ :+ SetProcessingLatencyMetric(latency))
+
+    def setE2ELatency(latency: FiniteDuration): IO[Unit] =
+      ref.update(_ :+ SetE2ELatencyMetric(latency))
 
     def report: Stream[IO, Nothing] = Stream.never[IO]
   }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/TestSparkEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/TestSparkEnvironment.scala
@@ -89,6 +89,7 @@ object TestSparkEnvironment {
     def addCommitted(count: Int): IO[Unit]                      = IO.unit
     def setLatency(latency: FiniteDuration): IO[Unit]           = IO.unit
     def setProcessingLatency(latency: FiniteDuration): IO[Unit] = IO.unit
+    def setE2ELatency(latency: FiniteDuration): IO[Unit]        = IO.unit
     def report: Stream[IO, Nothing]                             = Stream.never[IO]
   }
 

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/ProcessingSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.lakes/processing/ProcessingSpec.scala
@@ -58,6 +58,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000000"),
         Action.AddedCommittedCountMetric(4),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
+        Action.SetE2ELatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
         Action.Checkpointed(tokened.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000000")
       )
@@ -117,6 +118,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000000"),
         Action.AddedCommittedCountMetric(2),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
+        Action.SetE2ELatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
         Action.Checkpointed(window1.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000000"),
 
@@ -129,6 +131,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000052"),
         Action.AddedCommittedCountMetric(6),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration),
+        Action.SetE2ELatencyMetric(2 * MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
         Action.Checkpointed(window2.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000052"),
 
@@ -140,6 +143,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000134"),
         Action.AddedCommittedCountMetric(4),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration),
+        Action.SetE2ELatencyMetric(3 * MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
         Action.Checkpointed(window3.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000134")
       )
@@ -170,6 +174,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000000"),
         Action.AddedCommittedCountMetric(6),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
+        Action.SetE2ELatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
         Action.Checkpointed(tokened.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000000")
       )
@@ -212,6 +217,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000000"),
         Action.AddedCommittedCountMetric(8),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
+        Action.SetE2ELatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
         Action.Checkpointed((bads1 ::: goods1 ::: bads2 ::: goods2).map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000000")
       )
@@ -248,6 +254,8 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v20231024100032"),
         Action.AddedCommittedCountMetric(4),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
+        Action
+          .SetE2ELatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable + processTime.toEpochMilli.millis),
         Action.Checkpointed(tokened.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v20231024100032")
       )
@@ -285,6 +293,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000000"),
         Action.AddedCommittedCountMetric(2),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
+        Action.SetE2ELatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
         Action.Checkpointed(tokened.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000000")
       )
@@ -324,6 +333,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.CommittedToTheLake("v19700101000000"),
         Action.AddedCommittedCountMetric(1),
         Action.SetProcessingLatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
+        Action.SetE2ELatencyMetric(MockEnvironment.WindowDuration + MockEnvironment.TimeTakenToCreateTable),
         Action.Checkpointed(tokened.map(_.ack)),
         Action.RemovedDataFrameFromDisk("v19700101000000")
       )


### PR DESCRIPTION
The new metric is called `e2e_latency_millis` and it measures the difference between an event's `collector_tstamp` and when it committed to the lake.

The metric is emitted to statsd only on minutes in which some events are committed to the lake, i.e. the end of a window.  In other minutes (mid-window) the metric is not defined and not emitted to statsd.

The metric measures the worst-case latency for a window, i.e. latency for the earliest seen `collector_tstamp`.