### PR TITLE
DynamoDB table webhook messages

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -172,9 +172,9 @@ object Dependencies {
     awsS3,
     awsGlue,
     awsSts,
-    awsS3Transfer % Runtime,
+    dynamodbSdk1,
     deltaDynamodb % Runtime,
-    dynamodbSdk1  % Runtime
+    awsS3Transfer % Runtime
   ) ++ commonRuntimeDependencies
 
   val azureDependencies = Seq(


### PR DESCRIPTION
In #89 we added support for Delta's "S3 multi-cluster" mode, which uses a DynamoDB table to allow safe concurrent access by multiple loaders.

This PR extends the webhook feature, so the webhook receives a friendly error message if the DynamoDB table is mis-configured