### PR TITLE
Revert to unsorted Dataframe for Delta and Hudi

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/LakeWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/processing/LakeWriter.scala
@@ -155,7 +155,7 @@ object LakeWriter {
 
     def commit(viewName: String): F[Unit] =
       for {
-        df <- SparkUtils.prepareFinalDataFrame(spark, viewName, writerParallelism)
+        df <- SparkUtils.prepareFinalDataFrame(spark, viewName, writerParallelism, w.expectsSortedDataframe)
         _ <- mutex.lock
                .surround {
                  w.write(df)

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/DeltaWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/DeltaWriter.scala
@@ -111,4 +111,5 @@ class DeltaWriter(config: Config.Delta) extends Writer {
    */
   override def toleratesAsyncDelete: Boolean = true
 
+  override def expectsSortedDataframe: Boolean = false
 }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/HudiWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/HudiWriter.scala
@@ -94,4 +94,6 @@ class HudiWriter(config: Config.Hudi) extends Writer {
    * steps must happen in order.
    */
   override def toleratesAsyncDelete: Boolean = false
+
+  override def expectsSortedDataframe: Boolean = false
 }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergWriter.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/IcebergWriter.scala
@@ -112,4 +112,10 @@ class IcebergWriter(config: Config.Iceberg) extends Writer {
    * re-writes a file that was previously deleted
    */
   override def toleratesAsyncDelete: Boolean = true
+
+  /**
+   * Iceberg writer requires the Dataframe to be sorted, because we set the iceberg write option
+   * `distribution-mode = none`
+   */
+  override def expectsSortedDataframe: Boolean = true
 }

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/Writer.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.lakes/tables/Writer.scala
@@ -36,4 +36,10 @@ trait Writer {
    * If tolerated, then we use our customized `LakeLoaderFileSystem`.
    */
   def toleratesAsyncDelete: Boolean
+
+  /**
+   * Whether this writer expects the DataFrame to be sorted by the partition column, i.e. by
+   * event_name
+   */
+  def expectsSortedDataframe: Boolean
 }


### PR DESCRIPTION
In #102 I changed how we partition and sort the DataFrame before writing to the Lake.

The new partitioning is working well for all output formats. But the extra sort step is not strictly unnecessary for Delta and Hudi. This commit removes the sort step for Delta/Hudi only, to slightly improve cpu utilization.