### PR TITLE
Enable delete-after-commit on newly created Iceberg tables

### DIFF
--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -33,6 +33,7 @@
       "icebergTableProperties": {
         "write.spark.accept-any-schema": "true"
         "write.object-storage.enabled": "true"
+        "write.metadata.delete-after-commit.enabled": "true"
         "write.metadata.metrics.max-inferred-column-defaults": "0"
         "write.metadata.metrics.column.load_tstamp": "full"
         "write.metadata.metrics.column.collector_tstamp": "full"


### PR DESCRIPTION
Currently, the lake loader produces a very large number of Iceberg metadata files, which don't get cleaned up until the user runs a `deleteOrphanFiles` action.  This is a particular problem with the Lake Loader because of how it writes to the lake very frequently.

The Iceberg table option `write.metadata.delete-after-commit.enabled` can be used to managed the build up of redundant metadata files.

This PR only affects newly created tables. Existing lake loader users should manually alter their Iceberg table to set this property.