### PR TITLE
Better Iceberg table properties for metadata files

### DIFF
--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -33,6 +33,8 @@
       "icebergTableProperties": {
         "write.spark.accept-any-schema": "true"
         "write.object-storage.enabled": "true"
+        "write.metadata.delete-after-commit.enabled": "true"
+        "write.metadata.compression-codec": "gzip"
         "write.metadata.metrics.max-inferred-column-defaults": "0"
         "write.metadata.metrics.column.load_tstamp": "full"
         "write.metadata.metrics.column.collector_tstamp": "full"


### PR DESCRIPTION
This PR affects newly created Iceberg tables only. Existing lake loader users should manually alter their Iceberg table to set these properties.

**1. delete-after-commit**

Currently, the lake loader produces a very large number of Iceberg metadata files, which don't get cleaned up until the user runs a `deleteOrphanFiles` action.  This is a particular problem with the Lake Loader because of how it writes to the lake very frequently.

The Iceberg table option `write.metadata.delete-after-commit.enabled` should be used to prevent the build up of redundant metadata files.

**2. compression-codec**

For the Snowplow events table, the Iceberg metadata files can get very large, for a combination of reasons:

- We commit frequently, so there are many snapshots to track
- The parquet schema is large (i.e. many columns)
- We evolve the parquet schema often.  The metadata file tracks each revision to the schema.

The Iceberg table option `write.metadata.compression-codec` should be set to `gzip`, to alleviate the storage/network overhead of large metadata files.