### PR TITLE
Upgrade dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,6 +47,7 @@ object Dependencies {
     val awsSdk1     = "1.12.777"
     val awsSdk2     = "2.29.0" // Match common-streams
     val awsRegistry = "1.1.20"
+    val jsonSmart   = "2.5.2"
 
     // Snowplow
     val streams    = "0.10.0"
@@ -56,7 +57,7 @@ object Dependencies {
     val protobuf  = "3.25.5"
     val snappy    = "1.1.10.5"
     val thrift    = "0.21.0"
-    val netty     = "4.1.114.Final"
+    val netty     = "4.1.118.Final"
     val pubsubSdk = "1.134.1"
     val avro      = "1.11.4"
     val jackson   = "2.17.2"
@@ -103,6 +104,7 @@ object Dependencies {
   val awsSts        = "software.amazon.awssdk" % "sts"                   % V.awsSdk2
   val dynamodbSdk1  = "com.amazonaws"          % "aws-java-sdk-dynamodb" % V.awsSdk1
   val awsRegistry   = "software.amazon.glue"   % "schema-registry-serde" % V.awsRegistry
+  val jsonSmart     = "net.minidev"            % "json-smart"            % V.jsonSmart
 
   // transitive overrides
   val protobuf     = "com.google.protobuf"            % "protobuf-java"                      % V.protobuf
@@ -184,6 +186,7 @@ object Dependencies {
     azureIdentity,
     hadoopAzure,
     hadoopClient,
+    jsonSmart,
     kafkaClients % Runtime,
     specs2
   ) ++ commonRuntimeDependencies


### PR DESCRIPTION
Follow vulnerabilities remained for all variants:
```
Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538] in com.fasterxml.jackson.core:jackson-core@2.13.4
    introduced by org.apache.hadoop:hadoop-client-runtime@3.4.1 > com.fasterxml.jackson.core:jackson-core@2.12.7 and 2 other path(s)
  This issue was fixed in versions: 2.15.0-rc1
  ✗ Deserialization of Untrusted Data [Critical Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEAVRO-8161188] in org.apache.avro:avro@1.9.2
    introduced by org.apache.hadoop:hadoop-client-runtime@3.4.1 > org.apache.avro:avro@1.9.2
  This issue was fixed in versions: 1.11.4
```

They remained even after upgrading the version of vulnerable dependencies. I guess it is related with `hadoop-client-runtime` being packaged. We use latest version of `hadoop-client-runtime` therefore we can't upgrade it to newer version.